### PR TITLE
POC: add hnap validation

### DIFF
--- a/bridgemetadata/convert.py
+++ b/bridgemetadata/convert.py
@@ -5,6 +5,7 @@ import lxml.etree as ET
 from xml.etree.ElementTree import Element, SubElement
 from xml.etree import ElementTree
 from xml.dom import minidom
+from lxml import isoschematron
 
 class UnimplementedConversionException(Exception):
     pass
@@ -97,6 +98,27 @@ def _detect_format(dom):
     else:
         print ("Unknown source format")
         return None
+
+def validate():
+    if len(sys.argv) != 2:
+        print(
+            "Wrong number of parameters\nUsage: md-eval src"
+        )
+    else:
+        if os.path.exists(sys.argv[1]):
+            dom = ET.parse(sys.argv[1])
+            sch_src = _resource("iso19139.ca.hnap/schematron-rules-common.sch")
+            sch_doc = ET.parse(sch_src)
+            sch = isoschematron.Schematron(sch_doc, store_report = True)
+            validationResult = sch.validate(dom)
+            report = sch.validation_report
+            print("Is valid: " + str(validationResult))
+            if (not validationResult):
+                errors = report.xpath("svrl:failed-assert/svrl:text/text()",namespaces={'svrl':'http://purl.oclc.org/dsdl/svrl'})
+                print(errors)
+        else: 
+            print("File " + sys.argv[1] + " does not exist")
+            return None
 
 def main():
     if len(sys.argv) != 4:

--- a/bridgemetadata/resources/iso19139.ca.hnap/fromISO19139.xsl
+++ b/bridgemetadata/resources/iso19139.ca.hnap/fromISO19139.xsl
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="2.0"
+                xmlns:gmd="http://www.isotc211.org/2005/gmd"
+                xmlns:gco="http://www.isotc211.org/2005/gco"
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+
+    <!-- ISO19139 are compatible with HNAP however for to import to process then records as HNAP we need to ensure that the metadataStandardName is set correctly -->
+
+    <xsl:include href="../functions.xsl"/>
+
+    <xsl:variable name="metadataStandardNameEng"
+                  select="'North American Profile of ISO 19115:2003 - Geographic information - Metadata'"/>
+    <xsl:variable name="metadataStandardNameFre"
+                  select="'Profil nord-américain de la norme ISO 19115:2003 - Information géographique - Métadonnées'"/>
+    <xsl:variable name="metadataStandardVersion" select="'CAN/CGSB-171.100-2009'"/>
+
+
+    <!-- The default language is also added as gmd:locale
+   for multilingual metadata records. -->
+    <xsl:variable name="mainLanguage">
+        <xsl:call-template name="langId_from_gmdlanguage19139">
+            <xsl:with-param name="gmdlanguage" select="/root/*/gmd:language"/>
+        </xsl:call-template>
+    </xsl:variable>
+
+    <xsl:template
+            match="gmd:metadataStandardName/gco:CharacterString[text()!=$metadataStandardNameEng and text()!=$metadataStandardNameFre]"
+            priority="10">
+        <xsl:copy>
+            <xsl:choose>
+                <xsl:when test="$mainLanguage='fra'">
+                    <xsl:value-of select="$metadataStandardNameFre"/>
+                </xsl:when>
+                <xsl:otherwise>
+                    <xsl:value-of select="$metadataStandardNameEng"/>
+                </xsl:otherwise>
+            </xsl:choose>
+        </xsl:copy>
+    </xsl:template>
+
+    <xsl:template
+            match="gmd:metadataStandardName/gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[text()!=$metadataStandardNameEng and text()!=$metadataStandardNameFre]"
+            priority="10">
+        <xsl:copy>
+
+            <xsl:choose>
+                <xsl:when test="$mainLanguage!='fra'">
+                    <xsl:value-of select="$metadataStandardNameFre"/>
+                </xsl:when>
+                <xsl:otherwise>
+                    <xsl:value-of select="$metadataStandardNameEng"/>
+                </xsl:otherwise>
+            </xsl:choose>
+        </xsl:copy>
+    </xsl:template>
+
+    <xsl:template match="gmd:metadataStandardVersion/gco:CharacterString[text()!=$metadataStandardVersion]"
+                  priority="10">
+        <xsl:copy>
+            <xsl:value-of select="$metadataStandardVersion"/>
+        </xsl:copy>
+    </xsl:template>
+
+    <xsl:template match="node()|@*">
+        <xsl:copy>
+            <xsl:apply-templates select="node()|@*"/>
+        </xsl:copy>
+    </xsl:template>
+</xsl:stylesheet>

--- a/bridgemetadata/resources/iso19139.ca.hnap/schematron-rules-common.sch
+++ b/bridgemetadata/resources/iso19139.ca.hnap/schematron-rules-common.sch
@@ -1,0 +1,400 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sch:schema xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+            xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+            xmlns:geonet="http://www.fao.org/geonetwork"
+            xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+  <sch:ns prefix="gml" uri="http://www.opengis.net/gml/3.2"/>
+  <sch:ns prefix="gml320" uri="http://www.opengis.net/gml"/>
+  <sch:ns prefix="gmd" uri="http://www.isotc211.org/2005/gmd"/>
+  <sch:ns prefix="srv" uri="http://www.isotc211.org/2005/srv"/>
+  <sch:ns prefix="gco" uri="http://www.isotc211.org/2005/gco"/>
+  <sch:ns prefix="gmx" uri="http://www.isotc211.org/2005/gmx"/>
+  <sch:ns prefix="geonet" uri="http://www.fao.org/geonetwork"/>
+  <sch:ns prefix="xsl" uri="http://www.w3.org/1999/XSL/Transform"/>
+  <sch:ns prefix="xlink" uri="http://www.w3.org/1999/xlink"/>
+  <sch:ns prefix="rdf" uri="http://www.w3.org/1999/02/22-rdf-syntax-ns#"/>
+  <sch:ns prefix="ns2" uri="http://www.w3.org/2004/02/skos/core#"/>
+  <sch:ns prefix="rdfs" uri="http://www.w3.org/2000/01/rdf-schema#"/>
+
+  <sch:let name="schema" value="'iso19139.ca.HNAP'"/>
+  <sch:let name="mainLanguage" value="'eng'"/>                            
+  <sch:let name="mainLanguageId" value="//*[name(.)='gmd:MD_Metadata' or @gco:isoType='gmd:MD_Metadata']/gmd:locale/gmd:PT_Locale[gmd:languageCode/*/@codeListValue = $mainLanguage]/@id"/>
+  <sch:let name="mainLanguageText" value="'English'"/>
+  <sch:let name="mainLanguage2char" value="'en'"/>
+
+  <!--- Metadata pattern -->
+  <sch:pattern>
+    <!-- HierarchyLevel -->
+    <sch:rule context="//gmd:hierarchyLevel">
+      <sch:let name="missing" value="not(string(gmd:MD_ScopeCode/@codeListValue)) or (@gco:nilReason)" />
+      <sch:let name="hierarchyLevelCodelistLabel" value="@codeListValue"/>
+      <sch:let name="isValid" value="($hierarchyLevelCodelistLabel != '') and ($hierarchyLevelCodelistLabel != gmd:MD_ScopeCode/@codeListValue)"/>
+      <sch:assert test="not($missing)">HierarchyLevel</sch:assert>
+      <sch:assert test="$isValid or $missing">InvalidHierarchyLevel</sch:assert>
+    </sch:rule>
+
+
+    <!-- referenceSystemInfo -->
+    <!-- Mandatory, if spatialRepresentionType in Data Identification is "vector," "grid" or "tin”. -->
+    <sch:rule context="/gmd:MD_Metadata">
+      <sch:let name="missing" value="not(gmd:referenceSystemInfo)
+                " />
+
+      <sch:let name="sRequireRefSystemInfo" value="count(//gmd:identificationInfo/*/gmd:spatialRepresentationType/gmd:MD_SpatialRepresentationTypeCode[@codeListValue= 'RI_635']) +
+                                                     count(//gmd:identificationInfo/*/gmd:spatialRepresentationType/gmd:MD_SpatialRepresentationTypeCode[@codeListValue= 'RI_636']) +
+                                                     count(//gmd:identificationInfo/*/gmd:spatialRepresentationType/gmd:MD_SpatialRepresentationTypeCode[@codeListValue= 'RI_638'])" />
+
+      <sch:assert
+        test="(($sRequireRefSystemInfo > 0) and not($missing)) or $sRequireRefSystemInfo = 0">ReferenceSystemInfo</sch:assert>
+    </sch:rule>
+
+    <sch:rule context="//gmd:referenceSystemInfo/gmd:MD_ReferenceSystem/gmd:referenceSystemIdentifier/gmd:RS_Identifier/gmd:code">
+      <sch:let name="missing" value="not(string(gco:CharacterString))" />
+      <sch:assert test="not($missing)">ReferenceSystemInfoCode</sch:assert>
+    </sch:rule>
+
+    <!-- Contact - Role 
+    <sch:rule context="//gmd:contact/*/gmd:role">
+      <sch:let name="roleCodelistLabel" value="gmd:CI_RoleCode/@codeListValue"/>
+      <sch:let name="missing" value="not(string(gmd:CI_RoleCode/@codeListValue)) or (@gco:nilReason)" />
+      <sch:assert test="not($missing)">MissingContactRole</sch:assert>
+      <sch:let name="isValid" value="($roleCodelistLabel != '') and ($roleCodelistLabel != gmd:CI_RoleCode/@codeListValue)"/>
+
+      <sch:assert  test="$isValid or $missing">InvalidContactRole</sch:assert>
+
+    </sch:rule>-->
+  </sch:pattern>
+
+
+  <!--- Data Identification pattern -->
+  <sch:pattern>
+
+    <!-- Status 
+    <sch:rule context="//gmd:identificationInfo/*/gmd:status
+                     |//*[@gco:isoType='gmd:MD_DataIdentification']/gmd:status
+                     |//*[@gco:isoType='srv:SV_ServiceIdentification']/gmd:status">
+
+      <sch:let name="missing" value="not(string(gmd:MD_ProgressCode/@codeListValue))
+                 or (@gco:nilReason)" />
+
+      <sch:assert test="not($missing)">Status</sch:assert>
+
+      <sch:let name="statusCodelistLabel" value="gmd:MD_ProgressCode/@codeListValue"/>
+
+      <sch:let name="isValid" value="($statusCodelistLabel != '') and ($statusCodelistLabel != gmd:MD_ProgressCode/@codeListValue)"/>
+
+      <sch:assert
+        test="$isValid or $missing"
+      >InvalidStatusCode</sch:assert>
+
+    </sch:rule>-->
+
+
+    <!-- Topic Category -->
+    <sch:rule context="//gmd:identificationInfo/*/gmd:topicCategory
+            |//*[@gco:isoType='gmd:MD_DataIdentification']/gmd:topicCategory
+            |//*[@gco:isoType='srv:SV_ServiceIdentification']/gmd:topicCategory">
+
+      <sch:let name="missing" value="not(string(gmd:MD_TopicCategoryCode))
+                " />
+
+      <sch:assert
+        test="not($missing)"
+      >TopicCategory</sch:assert>
+    </sch:rule>
+
+
+    <!-- Spatial Representation Type 
+    <sch:rule context="//gmd:identificationInfo/*/gmd:spatialRepresentationType
+                   |//*[@gco:isoType='gmd:MD_DataIdentification']/gmd:spatialRepresentationType
+                   |//*[@gco:isoType='srv:SV_ServiceIdentification']/gmd:spatialRepresentationType">
+
+      <sch:let name="missing" value="not(string(gmd:MD_SpatialRepresentationTypeCode/@codeListValue))
+                 or (@gco:nilReason)" />
+
+      <sch:assert
+        test="not($missing)"
+      >SpatialRepresentation</sch:assert>
+
+
+      <sch:let name="spatialRepresentationTypeCodelistLabel"
+               value="gmd:MD_SpatialRepresentationTypeCode/@codeListValue"/>
+
+      <sch:let name="isValid" value="($spatialRepresentationTypeCodelistLabel != '') and ($spatialRepresentationTypeCodelistLabel != gmd:MD_SpatialRepresentationTypeCode/@codeListValue)"/>
+
+      <sch:assert
+        test="$isValid or $missing"
+      >InvalidSpatialRepresentationType</sch:assert>
+    </sch:rule>-->
+
+
+    <!-- Creation/revision dates 
+    <sch:rule context="//gmd:identificationInfo/*/gmd:citation/gmd:CI_Citation
+            |//*[@gco:isoType='gmd:MD_DataIdentification']/gmd:citation/gmd:CI_Citation
+            |//*[@gco:isoType='srv:SV_ServiceIdentification']/gmd:citation/gmd:CI_Citation">
+
+      <sch:let name="missingPublication" value="count(gmd:date[gmd:CI_Date/gmd:dateType/gmd:CI_DateTypeCode/@codeListValue = 'RI_367']) = 0" />
+
+      <sch:assert
+        test="not($missingPublication)"
+      >PublicationDate</sch:assert>
+
+      <sch:let name="missingCreation" value="count(gmd:date[gmd:CI_Date/gmd:dateType/gmd:CI_DateTypeCode/@codeListValue = 'RI_366']) = 0" />
+
+      <sch:assert
+        test="not($missingCreation)"
+      >CreationDate</sch:assert>
+
+    </sch:rule>-->
+
+    <sch:rule context="//gmd:identificationInfo/*/gmd:citation/gmd:CI_Citation/gmd:date/gmd:CI_Date/gmd:date
+            |//*[@gco:isoType='gmd:MD_DataIdentification']/gmd:citation/gmd:CI_Citation/gmd:date/gmd:CI_Date/gmd:date
+            |//*[@gco:isoType='srv:SV_ServiceIdentification']/gmd:citation/gmd:CI_Citation/gmd:date/gmd:CI_Date/gmd:date">
+
+      <sch:let name="missing" value="not(string(gco:Date)) and not(string(gco:DateTime))
+                    " />
+
+      <sch:assert
+        test="not($missing)"
+      >MissingDate</sch:assert>
+    </sch:rule>
+
+
+    <sch:rule context="//gmd:identificationInfo/*/gmd:citation/gmd:CI_Citation/gmd:date/gmd:CI_Date/gmd:dateType
+            |//*[@gco:isoType='gmd:MD_DataIdentification']/gmd:citation/gmd:CI_Citation/gmd:date/gmd:CI_Date/gmd:dateType
+            |//*[@gco:isoType='srv:SV_ServiceIdentification']/gmd:citation/gmd:CI_Citation/gmd:date/gmd:CI_Date/gmd:dateType">
+
+      <sch:let name="dateTypeCodelistLabel"
+               value="gmd:CI_DateTypeCode/@codeListValue"/>
+
+      <sch:let name="missing" value="not(string(gmd:CI_DateTypeCode/@codeListValue))
+                 or (@gco:nilReason)" />
+
+      <sch:let name="isValid" value="($dateTypeCodelistLabel != '') and ($dateTypeCodelistLabel != gmd:CI_DateTypeCode/@codeListValue)"/>
+
+      <sch:assert
+        test="$isValid or $missing"
+      >InvalidDateTypeCode</sch:assert>
+
+    </sch:rule>
+
+    <!-- Begin position 
+    <sch:rule context="//gmd:identificationInfo/*/gmd:extent/gmd:EX_Extent/gmd:temporalElement">
+
+      <sch:let name="beginPosition" value="gmd:EX_TemporalExtent/gmd:extent/gml:TimePeriod//gml:beginPosition" />
+      <sch:let name="missingBeginPosition" value="not(string($beginPosition))" />
+
+      <sch:assert test="not($missingBeginPosition)">BeginDate</sch:assert>
+      <sch:assert test="$missingBeginPosition or $beginPosition &gt; 0)">BeginPositionFormat</sch:assert>
+
+
+      <sch:let name="endPosition" value="gmd:EX_TemporalExtent/gmd:extent/gml:TimePeriod//gml:endPosition" />
+      <sch:let name="missingEndPosition" value="not(string($endPosition))" />
+
+      <sch:assert test="$missingBeginPosition or $missingEndPosition or $endPosition &gt;= 0)">EndPosition</sch:assert>
+    </sch:rule>-->
+
+
+    <!-- Dataset language -->
+    <sch:rule context="//gmd:identificationInfo/*/gmd:language
+                   |//*[@gco:isoType='gmd:MD_DataIdentification']/gmd:language
+                   |//*[@gco:isoType='srv:SV_ServiceIdentification']/gmd:language">
+
+      <sch:let name="missing" value="not(string(gco:CharacterString))
+               or (@gco:nilReason)" />
+
+      <sch:assert
+        test="not($missing)"
+      >DataLanguage</sch:assert>
+    </sch:rule>
+
+    <!-- Maintenance and frequency 
+    <sch:rule context="//gmd:identificationInfo/*/gmd:resourceMaintenance/gmd:MD_MaintenanceInformation/gmd:maintenanceAndUpdateFrequency
+                   |//*[@gco:isoType='gmd:MD_DataIdentification']/gmd:resourceMaintenance/gmd:MD_MaintenanceInformation/gmd:maintenanceAndUpdateFrequency
+                   |//*[@gco:isoType='srv:SV_ServiceIdentification']/gmd:resourceMaintenance/gmd:MD_MaintenanceInformation/gmd:maintenanceAndUpdateFrequency">
+
+      <sch:let name="missing" value="not(string(gmd:MD_MaintenanceFrequencyCode/@codeListValue))
+               or (@gco:nilReason)" />
+
+      <sch:assert
+        test="not($missing)"
+      >MaintenanceFrequency</sch:assert>
+
+
+      <sch:let name="maintenanceFrequencyCodelistLabel"
+               value="gmd:MD_MaintenanceFrequencyCode/@codeListValue"/>
+
+      <sch:let name="isValid" value="($maintenanceFrequencyCodelistLabel != '') and ($maintenanceFrequencyCodelistLabel != gmd:MD_MaintenanceFrequencyCode/@codeListValue)"/>
+
+      <sch:assert
+        test="$isValid or $missing"
+      >InvalidMaintenanceFrequency</sch:assert>
+    </sch:rule>-->
+
+
+    <!-- Cited Responsible Party - Role 
+    <sch:rule context="//gmd:identificationInfo/*/gmd:citation/*/gmd:citedResponsibleParty/*/gmd:role
+      |//*[@gco:isoType='gmd:MD_DataIdentification']/gmd:citation/*/gmd:citedResponsibleParty/*/gmd:role
+      |//*[@gco:isoType='srv:SV_ServiceIdentification']/gmd:citation/*/gmd:citedResponsibleParty/*/gmd:role">
+
+      <sch:let name="roleCodelistLabel"
+               value="gmd:CI_RoleCode/@codeListValue"/>
+
+      <sch:let name="missing" value="not(string(gmd:CI_RoleCode/@codeListValue))
+        or (@gco:nilReason)" />
+
+      <sch:assert
+        test="not($missing)"
+      >MissingCitedResponsibleRole</sch:assert>
+
+      <sch:let name="isValid" value="($roleCodelistLabel != '') and ($roleCodelistLabel != gmd:CI_RoleCode/@codeListValue)"/>
+
+      <sch:assert
+        test="$isValid or $missing"
+      >InvalidCitedResponsibleRole</sch:assert>
+
+    </sch:rule>-->
+
+
+    <!-- Core Subject Thesaurus 
+    <sch:rule context="//gmd:identificationInfo/gmd:MD_DataIdentification
+            |//*[@gco:isoType='gmd:MD_DataIdentification']
+            |//*[@gco:isoType='srv:SV_ServiceIdentification']">
+
+<sch:let name="coreSubjectThesaurusExists"
+               value="count(gmd:descriptiveKeywords[*/gmd:thesaurusName/*/gmd:title/*/text() = 'Government of Canada Core Subject Thesaurus' or
+              */gmd:thesaurusName/*/gmd:title/*/text() = 'Thésaurus des sujets de base du gouvernement du Canada']) > 0" />
+
+      <sch:assert test="$coreSubjectThesaurusExists">CoreSubjectThesaurusMissing</sch:assert>
+    </sch:rule>-->
+
+    <!-- Access constraints 
+    <sch:rule context="//gmd:identificationInfo/*/gmd:resourceConstraints/gmd:MD_LegalConstraints/gmd:accessConstraints">
+
+      <sch:let name="missing" value="not(string(gmd:MD_RestrictionCode/@codeListValue))" />
+
+      <sch:assert
+        test="not($missing)"
+      >MissingAccessConstraints</sch:assert>
+
+      <sch:let name="accessConstraintsCodelistLabel"
+               value="gmd:MD_RestrictionCode/@codeListValue"/>
+
+      <sch:let name="isValid" value="($accessConstraintsCodelistLabel != '') and ($accessConstraintsCodelistLabel != gmd:MD_RestrictionCode/@codeListValue)"/>
+
+      <sch:assert
+        test="$isValid or $missing"
+      >InvalidAccessConstraints</sch:assert>
+    </sch:rule>-->
+
+    <!-- Use constraints 
+    <sch:rule context="//gmd:identificationInfo/*/gmd:resourceConstraints/gmd:MD_LegalConstraints/gmd:useConstraints">
+
+      <sch:let name="missing" value="not(string(gmd:MD_RestrictionCode/@codeListValue))" />
+
+      <sch:assert
+        test="not($missing)"
+      >MissingUseConstraints</sch:assert>
+
+      <sch:let name="useConstraintsCodelistLabel"
+               value="gmd:MD_RestrictionCode/@codeListValue"/>
+
+      <sch:let name="isValid" value="($useConstraintsCodelistLabel != '') and ($useConstraintsCodelistLabel != gmd:MD_RestrictionCode/@codeListValue)"/>
+
+      <sch:assert
+        test="$isValid or $missing"
+      >InvalidUseConstraints</sch:assert>
+    </sch:rule>-->
+  </sch:pattern>
+
+
+  
+  <sch:pattern>
+<!-- Distribution - Resources 
+    <sch:rule context="//gmd:distributionInfo/gmd:MD_Distribution/gmd:transferOptions/gmd:MD_DigitalTransferOptions/gmd:onLine/gmd:CI_OnlineResource/gmd:linkage/gmd:URL">
+
+      <sch:let name="missing" value="not(string(.)) and not(string(../../../../gmd:onLine[@xlink:role!=../../../@xlink:role and @xlink:title=../../../@xlink:title]/gmd:CI_OnlineResource/gmd:linkage/gmd:URL))
+                and (string(../../gmd:protocol/gco:CharacterString) or
+                string(../../gmd:name/gco:CharacterString) or
+                string(../../../../gmd:onLine[@xlink:role!=../../../@xlink:role and @xlink:title=../../../@xlink:title]/gmd:CI_OnlineResource/gmd:name/gco:CharacterString) or
+                string(../../../../gmd:onLine[@xlink:role!=../../../@xlink:role and @xlink:title=../../../@xlink:title]/gmd:CI_OnlineResource/gmd:description/gco:CharacterString) or
+                string(../../gmd:description/gco:CharacterString))"
+      />
+
+      <sch:assert
+        test="not($missing)"
+      >OnlineResourceUrl</sch:assert>
+
+    </sch:rule>-->
+
+
+    <!-- Online resource: MapResourcesREST, MapResourcesWMS
+    <sch:rule context="//gmd:distributionInfo/gmd:MD_Distribution">
+      <sch:let name="smallcase" value="'abcdefghijklmnopqrstuvwxyz'" />
+      <sch:let name="uppercase" value="'ABCDEFGHIJKLMNOPQRSTUVWXYZ'" />
+
+      <sch:let name="mapRESTCount" value="count(gmd:transferOptions/gmd:MD_DigitalTransferOptions/gmd:onLine[@xlink:role='urn:xml:lang:eng-CAN' and translate(gmd:CI_OnlineResource/gmd:protocol/gco:CharacterString, $uppercase, $smallcase) = 'esri rest: map service']) +
+                count(gmd:transferOptions/gmd:MD_DigitalTransferOptions/gmd:onLine[@xlink:role='urn:xml:lang:fra-CAN' and translate(gmd:CI_OnlineResource/gmd:protocol/gco:CharacterString, $uppercase, $smallcase) = 'esri rest: map service'])" />
+
+      <sch:assert test="$mapRESTCount &lt;= 2">MapResourcesRESTNumber</sch:assert>
+      <sch:assert test="$mapRESTCount = 0 or $mapRESTCount = 2 or $mapRESTCount &gt; 2">MapResourcesREST</sch:assert>
+
+      <sch:let name="mapWMSCount" value="count(gmd:transferOptions/gmd:MD_DigitalTransferOptions/gmd:onLine[@xlink:role='urn:xml:lang:eng-CAN' and translate(gmd:CI_OnlineResource/gmd:protocol/gco:CharacterString, $uppercase, $smallcase) = 'ogc:wms']) +
+                count(gmd:transferOptions/gmd:MD_DigitalTransferOptions/gmd:onLine[@xlink:role='urn:xml:lang:fra-CAN' and translate(gmd:CI_OnlineResource/gmd:protocol/gco:CharacterString, $uppercase, $smallcase) = 'ogc:wms'])" />
+
+      <sch:assert test="$mapWMSCount &lt;= 2">MapResourcesWMSNumber</sch:assert>
+      <sch:assert test="$mapWMSCount = 0 or $mapWMSCount = 2 or $mapWMSCount &gt; 2">MapResourcesWMS</sch:assert>
+    </sch:rule>-->
+
+    <!-- Distribution - Format 
+    <sch:rule context="//gmd:distributionInfo/*/gmd:distributionFormat/*/gmd:name">
+
+      <sch:let name="missing" value="not(string(gco:CharacterString))
+                or (@gco:nilReason)" />
+
+      <sch:assert
+        test="not($missing)"
+      >DistributionFormatName</sch:assert>
+
+      <sch:let name="distribution-formats" value="document(concat('file:///', replace(concat($thesaurusDir, '/external/thesauri/theme/GC_Resource_Formats.rdf'), '\\', '/')))"/>
+
+      <sch:let name="distributionFormat" value="gco:CharacterString" />
+
+      <sch:assert test="($missing) or (string($distribution-formats//rdf:Description[normalize-space(ns2:prefLabel[@xml:lang=$mainLanguage2char]) = $distributionFormat]))">DistributionFormatInvalid</sch:assert>
+
+    </sch:rule>
+
+
+    <sch:rule context="//gmd:distributionInfo/*/gmd:distributionFormat/*/gmd:version">
+
+      <sch:let name="missing" value="not(string(gco:CharacterString))
+                or (@gco:nilReason)" />
+
+      <sch:assert
+        test="not($missing)"
+      >DistributionFormatVersion</sch:assert>
+
+    </sch:rule>-->
+
+    <!-- Distributor - Role 
+    <sch:rule context="//gmd:distributionInfo/*/gmd:distributor/gmd:MD_Distributor/gmd:distributorContact/*/gmd:role">
+
+      <sch:let name="roleCodelistLabel"
+               value="gmd:CI_RoleCode/@codeListValue"/>
+
+      <sch:let name="missing" value="not(string(gmd:CI_RoleCode/@codeListValue))
+        or (@gco:nilReason)" />
+
+      <sch:assert
+        test="not($missing)"
+      >MissingDistributorRole</sch:assert>
+
+      <sch:let name="isValid" value="($roleCodelistLabel != '') and ($roleCodelistLabel != gmd:CI_RoleCode/@codeListValue)"/>
+
+      <sch:assert
+        test="$isValid or $missing"
+      >InvalidDistributorRole</sch:assert>
+    </sch:rule>-->
+  </sch:pattern>
+</sch:schema>

--- a/bridgemetadata/resources/iso19139.ca.hnap/schematron-rules-multilingual.sch
+++ b/bridgemetadata/resources/iso19139.ca.hnap/schematron-rules-multilingual.sch
@@ -1,0 +1,870 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sch:schema xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+            xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+            xmlns:geonet="http://www.fao.org/geonetwork"
+            xmlns:xs="http://www.w3.org/2001/XMLSchema"
+            queryBinding="xslt2">
+
+  <sch:title xmlns="http://www.w3.org/2001/XMLSchema">HNAP validation rules (multilingual)</sch:title>
+  <sch:ns prefix="gml" uri="http://www.opengis.net/gml/3.2"/>
+  <sch:ns prefix="gml320" uri="http://www.opengis.net/gml"/>
+  <sch:ns prefix="gmd" uri="http://www.isotc211.org/2005/gmd"/>
+  <sch:ns prefix="srv" uri="http://www.isotc211.org/2005/srv"/>
+  <sch:ns prefix="gco" uri="http://www.isotc211.org/2005/gco"/>
+  <sch:ns prefix="gmx" uri="http://www.isotc211.org/2005/gmx"/>
+  <sch:ns prefix="geonet" uri="http://www.fao.org/geonetwork"/>
+  <sch:ns prefix="xsl" uri="http://www.w3.org/1999/XSL/Transform"/>
+  <sch:ns prefix="XslUtilHnap" uri="java:ca.gc.schema.iso19139hnap.util.XslUtilHnap"/>
+  <sch:ns prefix="tr" uri="java:org.fao.geonet.api.records.formatters.SchemaLocalizations"/>
+  <sch:ns prefix="xlink" uri="http://www.w3.org/1999/xlink"/>
+  <sch:ns prefix="rdf" uri="http://www.w3.org/1999/02/22-rdf-syntax-ns#"/>
+  <sch:ns prefix="ns2" uri="http://www.w3.org/2004/02/skos/core#"/>
+  <sch:ns prefix="rdfs" uri="http://www.w3.org/2000/01/rdf-schema#"/>
+
+  <sch:let name="schema" value="'iso19139.ca.HNAP'"/>
+  <sch:let name="mainLanguage" value="if (normalize-space(//*[name(.)='gmd:MD_Metadata' or @gco:isoType='gmd:MD_Metadata']/gmd:language/gmd:LanguageCode/@codeListValue) != '')
+                                       then lower-case(normalize-space(//*[name(.)='gmd:MD_Metadata' or @gco:isoType='gmd:MD_Metadata']/gmd:language/gmd:LanguageCode/@codeListValue))
+                                       else if (contains(//*[name(.)='gmd:MD_Metadata' or @gco:isoType='gmd:MD_Metadata']/gmd:language/gco:CharacterString,';'))
+                                            then lower-case(normalize-space(substring-before(//*[name(.)='gmd:MD_Metadata' or @gco:isoType='gmd:MD_Metadata']/gmd:language/gco:CharacterString,';')))
+                                            else lower-case(//*[name(.)='gmd:MD_Metadata' or @gco:isoType='gmd:MD_Metadata']/gmd:language/gco:CharacterString)"/>
+  <sch:let name="altLanguage" value="if ($mainLanguage = 'eng') then 'fra' else 'eng'"/>
+  <sch:let name="mainLanguageId" value="//*[name(.)='gmd:MD_Metadata' or @gco:isoType='gmd:MD_Metadata']/gmd:locale/gmd:PT_Locale[gmd:languageCode/*/@codeListValue = $mainLanguage]/@id"/>
+  <sch:let name="altLanguageId" value="//*[name(.)='gmd:MD_Metadata' or @gco:isoType='gmd:MD_Metadata']/gmd:locale/gmd:PT_Locale[gmd:languageCode/*/@codeListValue != $mainLanguage and (gmd:languageCode/*/@codeListValue = 'eng' or gmd:languageCode/*/@codeListValue = 'fra')]/@id"/>
+  <sch:let name="mainLanguage2char" value="if ($mainLanguage = 'fra') then 'fr' else 'en'"/>
+  <sch:let name="altLanguage2char" value="if (lower-case($altLanguage) = 'fra') then 'fr' else 'en'"/>
+  <sch:let name="mainLanguageText" value="if ($mainLanguage = 'fra') then 'French' else 'English'"/>
+  <sch:let name="altLanguageText" value="if (lower-case($altLanguage) = 'fra') then 'French' else 'English'"/>
+
+  <xsl:function name="geonet:resourceFormatsList" as="xs:string">
+    <xsl:param name="thesaurusDir" as="xs:string"/>
+
+    <xsl:variable name="formats-list" select="document(concat('file:///', replace(concat($thesaurusDir, '/external/thesauri/theme/GC_Resource_Formats.rdf'), '\\', '/')))"/>
+
+    <xsl:variable name="v">
+      <xsl:for-each select="$formats-list//rdf:Description[ns2:prefLabel[@xml:lang='en']]">
+        <xsl:sort select="lower-case(@rdf:about)" order="ascending" />
+        <xsl:value-of select="replace(@rdf:about, 'http://geonetwork-opensource.org/EC/resourceformat#', '')" />
+        <xsl:if test="position() != last()">, </xsl:if>
+      </xsl:for-each>
+    </xsl:variable>
+
+    <xsl:value-of select="$v" />
+  </xsl:function>
+
+  <xsl:function name="geonet:securityLevelList" as="xs:string">
+    <xsl:param name="thesaurusDir" as="xs:string"/>
+
+    <xsl:variable name="security-level-list" select="document(concat('file:///', replace(concat($thesaurusDir, '/external/thesauri/theme/GC_Security_Level.rdf'), '\\', '/')))"/>
+
+    <xsl:variable name="v">
+      <xsl:for-each select="$security-level-list//rdf:Description[ns2:prefLabel[@xml:lang='en']]">
+        <xsl:sort select="lower-case(@rdf:about)" order="ascending" />
+        <xsl:value-of select="replace(@rdf:about, 'http://geonetwork-opensource.org/EC/GC_Security_Classification#', '')" />
+        <xsl:if test="position() != last()">, </xsl:if>
+      </xsl:for-each>
+    </xsl:variable>
+
+    <xsl:value-of select="$v" />
+  </xsl:function>
+
+  <!-- Checks if the values in arg (can be a comma separate list of items) are all in the searchStrings list -->
+  <xsl:function name="geonet:values-in" as="xs:boolean">
+    <xsl:param name="arg" as="xs:string?"/>
+    <xsl:param name="searchStrings" as="xs:string*"/>
+
+    <xsl:variable name="list" select="tokenize($arg, ',')" />
+    <xsl:sequence
+            select="
+            every $listValue in $list
+            satisfies exists($searchStrings[. = $listValue])
+            "
+    />
+  </xsl:function>
+
+  <!-- =============================================================
+  EC schematron rules for multilingual validation in metadata editor:
+  ============================================================= -->
+
+  <!--- Metadata pattern -->
+  <sch:pattern>
+    <sch:title>$loc/strings/Metadata</sch:title>
+
+    <!-- Metadata Standard Name -->
+    <sch:rule context="//gmd:metadataStandardName">
+
+      <sch:let name="correct" value="(gco:CharacterString = 'North American Profile of ISO 19115:2003 - Geographic information - Metadata' or
+                          gco:CharacterString = 'Profil nord-américain de la norme ISO 19115:2003 - Information géographique - Métadonnées') and
+
+                      (gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale=concat('#', $altLanguageId)] = 'North American Profile of ISO 19115:2003 - Geographic information - Metadata' or
+                       gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale=concat('#', $altLanguageId)] = 'Profil nord-américain de la norme ISO 19115:2003 - Information géographique - Métadonnées')
+                            " />
+
+      <sch:assert
+        test="$correct"
+      >$loc/strings/MetadataStandardName</sch:assert>
+    </sch:rule>
+
+
+    <!-- Contact - Organisation Name -->
+    <sch:rule context="//gmd:contact/*/gmd:organisationName">
+
+      <sch:let name="mdLang" value="tokenize(/gmd:MD_Metadata/gmd:language/gco:CharacterString, ';')[1]" />
+
+      <sch:let name="missing" value="not(string(gco:CharacterString))
+                or (@gco:nilReason)" />
+
+      <sch:let name="missingOtherLang" value="not(string(gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale=concat('#', $altLanguageId)]))" />
+
+      <sch:assert
+        test="not($missing) and not($missingOtherLang)"
+      >$loc/strings/ContactOrganisationName</sch:assert>
+
+      <sch:let name="government-titles" value="document(concat('file:///', replace(concat($thesaurusDir, '/external/thesauri/theme/GC_Departments.rdf'), '\\', '/')))"/>
+      <sch:let name="government-names" value="document(concat('file:///', replace(concat($thesaurusDir, '/external/thesauri/theme/GC_Org_Names.rdf'), '\\', '/')))"/>
+
+      <sch:let name="organisationName" value="gco:CharacterString" />
+      <sch:let name="isGovernmentOfCanada" value="starts-with(lower-case(normalize-space(tokenize($organisationName, ';')[1])), 'government of canada') or starts-with(lower-case(normalize-space(tokenize($organisationName, ';')[1])), 'gouvernement du canada')" />
+      <sch:let name="titleName" value="lower-case(normalize-space(tokenize($organisationName, ';')[2]))" />
+
+
+
+      <sch:let name="isGovernmentNameAllowed" value="(
+          string($government-names//rdf:Description[starts-with(normalize-space(lower-case($organisationName)), concat(normalize-space(lower-case(ns2:prefLabel[@xml:lang=$altLanguage2char])), ';'))]) or
+          string($government-names//rdf:Description[starts-with(normalize-space(lower-case($organisationName)), concat(normalize-space(lower-case(ns2:prefLabel[@xml:lang=$mainLanguage2char])), ';'))])
+        )"/>
+
+      <sch:let name="isErrorContactGovMain" value="not(($missing and $missingOtherLang) or ($isGovernmentNameAllowed and not($isGovernmentOfCanada)) or (not($isGovernmentNameAllowed) and not($isGovernmentOfCanada)) or ($isGovernmentOfCanada and (string($government-titles//rdf:Description[normalize-space(lower-case(ns2:prefLabel[@xml:lang=$mainLanguage2char])) = $titleName]) or
+                string($government-titles//rdf:Description[normalize-space(lower-case(ns2:prefLabel[@xml:lang=$altLanguage2char])) = $titleName]))
+                     ))"/>
+
+      <sch:let name="isErrorContactGovMainAllowed" value="not($isErrorContactGovMain) and not(
+                ($missing and $missingOtherLang) or
+                $isGovernmentNameAllowed
+                )"/>
+
+      <sch:assert test="not($isErrorContactGovMain)">$loc/strings/*[name() = concat('ContactGov', $mainLanguageText)]</sch:assert>
+
+      <sch:assert test="not($isErrorContactGovMainAllowed)">$loc/strings/*[name() = concat('ContactGovAllowed', $mainLanguageText)]</sch:assert>
+
+      <sch:let name="organisationNameOtherLang" value="gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale=concat('#', $altLanguageId)]" />
+      <sch:let name="isGovernmentOfCanadaOtherLang" value="starts-with(lower-case(normalize-space(tokenize($organisationNameOtherLang, ';')[1])), 'government of canada') or starts-with(lower-case(normalize-space(tokenize($organisationNameOtherLang, ';')[1])), 'gouvernement du canada')" />
+      <sch:let name="titleNameOtherLang" value="lower-case(normalize-space(tokenize($organisationNameOtherLang, ';')[2]))" />
+      <sch:let name="isGovernmentNameAllowedOtherLang" value="(
+          string($government-names//rdf:Description[starts-with(normalize-space(lower-case($organisationNameOtherLang)), concat(normalize-space(lower-case(ns2:prefLabel[@xml:lang=$altLanguage2char])), ';'))]) or
+          string($government-names//rdf:Description[starts-with(normalize-space(lower-case($organisationNameOtherLang)), concat(normalize-space(lower-case(ns2:prefLabel[@xml:lang=$mainLanguage2char])), ';'))])
+        )"/>
+
+      <sch:let name="isErrorContactGovAlt" value="not($isErrorContactGovMain or $isErrorContactGovMainAllowed) and not(
+                ($missing and $missingOtherLang) or ($isGovernmentNameAllowed and not($isGovernmentOfCanada)) or (not($isGovernmentNameAllowed) and not($isGovernmentOfCanada)) or ($isGovernmentOfCanada and (string($government-titles//rdf:Description[normalize-space(lower-case(ns2:prefLabel[@xml:lang=$mainLanguage2char])) = $titleName]) or
+                string($government-titles//rdf:Description[normalize-space(lower-case(ns2:prefLabel[@xml:lang=$altLanguage2char])) = $titleName]))
+                     )
+                 )"/>
+
+      <sch:let name="isErrorContactGovAltAllowed" value="not($isErrorContactGovMain or $isErrorContactGovMainAllowed or $isErrorContactGovAlt)  and not(
+                ($missing and $missingOtherLang) or
+                $isGovernmentNameAllowed
+                )"/>
+
+      <sch:assert test="not($isErrorContactGovAlt)">$loc/strings/*[name() = concat('ContactGov', $altLanguageText)]</sch:assert>
+      <sch:assert test="not($isErrorContactGovAltAllowed)">$loc/strings/*[name() = concat('ContactGovAllowed', $altLanguageText)]</sch:assert>
+
+    </sch:rule>
+
+
+    <!-- Contact - Position name -->
+    <sch:rule context="//gmd:contact/*/gmd:positionName">
+
+      <sch:let name="missing" value="not(string(gco:CharacterString))
+                or (@gco:nilReason)" />
+
+      <sch:let name="missingOtherLang" value="not(string(gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale=concat('#', $altLanguageId)]))" />
+
+      <sch:assert
+        test="($missing and $missingOtherLang) or (not($missing) and not($missingOtherLang))"
+      >$loc/strings/ContactPositionName</sch:assert>
+
+    </sch:rule>
+
+
+    <!-- Contact - Country -->
+    <sch:rule context="//gmd:contact//gmd:country">
+      <sch:let name="country-values" value="document(concat('file:///', replace(concat($thesaurusDir, '/external/thesauri/theme/ISO_Countries.rdf'), '\\', '/')))"/>
+
+      <sch:let name="countryName" value="lower-case(gco:CharacterString)" />
+      <sch:let name="countryNameOtherLang" value="lower-case(gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale=concat('#', $altLanguageId)])" />
+
+      <sch:assert test="(not($countryName) or
+           ($countryName and (string($country-values//rdf:Description[lower-case(normalize-space(ns2:prefLabel[@xml:lang=$mainLanguage2char])) = $countryName]) or
+           string($country-values//rdf:Description[lower-case(normalize-space(ns2:prefLabel[@xml:lang=$altLanguage2char])) = $countryName]))))
+
+           and
+
+           (not($countryNameOtherLang) or
+                       ($countryNameOtherLang and (string($country-values//rdf:Description[lower-case(normalize-space(ns2:prefLabel[@xml:lang=$mainLanguage2char])) = $countryNameOtherLang]) or
+                       string($country-values//rdf:Description[lower-case(normalize-space(ns2:prefLabel[@xml:lang=$altLanguage2char])) = $countryNameOtherLang]))
+                       ))">$loc/strings/ECCountry</sch:assert>
+
+
+    </sch:rule>
+
+
+    <!-- Contact - Delivery point -->
+    <sch:rule context="//gmd:contact/*/gmd:contactInfo//gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:deliveryPoint">
+
+      <sch:let name="missing" value="not(string(gco:CharacterString))
+                " />
+
+      <sch:let name="missingOtherLang" value="not(string(gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale=concat('#', $altLanguageId)]))" />
+
+      <sch:assert
+        test="($missing and $missingOtherLang) or (not($missing) and not($missingOtherLang))"
+      >$loc/strings/ContactDeliveryPoint</sch:assert>
+    </sch:rule>
+
+
+    <!-- Contact - Phone -->
+    <sch:rule context="//gmd:contact/*/gmd:contactInfo/*/gmd:phone/gmd:CI_Telephone/gmd:voice">
+
+      <sch:let name="missing" value="not(string(gco:CharacterString))
+              " />
+
+      <sch:let name="missingOtherLang" value="not(string(gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale=concat('#', $altLanguageId)]))" />
+
+      <sch:assert
+        test="($missing and $missingOtherLang) or (not($missing) and not($missingOtherLang))"
+      >$loc/strings/ContactPhone</sch:assert>
+    </sch:rule>
+
+
+    <!-- Contact - Electronic Mail -->
+    <sch:rule context="//gmd:contact/*/gmd:contactInfo/*/gmd:address/gmd:CI_Address/gmd:electronicMailAddress">
+
+      <sch:let name="missing" value="not(string(gco:CharacterString))
+                or (@gco:nilReason)" />
+
+      <sch:let name="missingOtherLang" value="not(string(gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale=concat('#', $altLanguageId)]))" />
+
+      <sch:assert
+        test="not($missing) and not($missingOtherLang)"
+
+      >$loc/strings/ContactElectronicMail</sch:assert>
+
+    </sch:rule>
+
+
+    <!-- Contact - Hours of service -->
+    <sch:rule context="//gmd:contact/*/gmd:contactInfo/gmd:CI_Contact/gmd:hoursOfService">
+
+      <sch:let name="missing" value="not(string(gco:CharacterString))
+                " />
+      <sch:let name="missingOtherLang" value="not(string(gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale=concat('#', $altLanguageId)]))" />
+
+      <sch:assert
+        test="($missing and $missingOtherLang) or (not($missing) and not($missingOtherLang))"
+      >$loc/strings/ContactHoursOfService</sch:assert>
+    </sch:rule>
+
+
+    <!-- Contact - Role -->
+    <sch:rule context="//gmd:contact/*/gmd:role">
+
+      <sch:let name="roleCodelistLabel"
+                     value="tr:codelist-value-label(
+                            tr:create($schema),
+                            gmd:CI_RoleCode/local-name(),
+                            gmd:CI_RoleCode/@codeListValue)"/>
+
+      <sch:let name="missing" value="not(string(gmd:CI_RoleCode/@codeListValue))
+                 or (@gco:nilReason)" />
+
+      <sch:assert
+        test="not($missing)"
+      >$loc/strings/MissingContactRole</sch:assert>
+
+      <sch:let name="isValid" value="($roleCodelistLabel != '') and ($roleCodelistLabel != gmd:CI_RoleCode/@codeListValue)"/>
+
+      <sch:assert
+        test="$isValid or $missing"
+      >$loc/strings/InvalidContactRole</sch:assert>
+
+    </sch:rule>
+  </sch:pattern>
+
+
+  <!--- Data Identification pattern -->
+  <sch:pattern>
+    <sch:title>$loc/strings/DataIdentification</sch:title>
+
+    <!-- Use Limitation -->
+    <!-- Use Limitation -->
+    <sch:rule context="//gmd:identificationInfo/gmd:MD_DataIdentification
+        |//*[@gco:isoType='gmd:MD_DataIdentification']
+        |//*[@gco:isoType='srv:SV_ServiceIdentification']">
+
+      <sch:let name="open-licenses" value="document(concat('file:///', replace(concat($thesaurusDir, '/external/thesauri/theme/GC_Open_Licenses.rdf'), '\\', '/')))"/>
+
+      <sch:let name="openLicense" value="count(gmd:resourceConstraints/gmd:MD_LegalConstraints/gmd:useLimitation[
+            (normalize-space(gco:CharacterString) = $open-licenses//rdf:Description/ns2:prefLabel[@xml:lang=$mainLanguage2char]) and
+            (normalize-space(gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale=concat('#', $altLanguageId)]) = $open-licenses//rdf:Description/ns2:prefLabel[@xml:lang=$altLanguage2char])
+            ])" />
+
+      <sch:assert
+        test="$openLicense > 0"
+      >$loc/strings/OpenLicense</sch:assert>
+
+    </sch:rule>
+
+    <!-- Title -->
+    <sch:rule context="//gmd:identificationInfo/*/gmd:citation/*/gmd:title
+            |//*[@gco:isoType='gmd:MD_DataIdentification']/gmd:citation/*/gmd:title
+            |//*[@gco:isoType='srv:SV_ServiceIdentification']/gmd:citation/*/gmd:title">
+
+      <sch:let name="missing" value="not(string(gco:CharacterString))
+                or (@gco:nilReason)" />
+
+      <sch:let name="missingOtherLang" value="not(string(gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale=concat('#', $altLanguageId)]))" />
+
+      <sch:assert
+        test="not($missing) and not($missingOtherLang)"
+        >$loc/strings/MetadataTitle</sch:assert>
+    </sch:rule>
+
+
+    <!-- Abstract -->
+    <sch:rule context="//gmd:identificationInfo/*/gmd:abstract
+                     |//*[@gco:isoType='gmd:MD_DataIdentification']/gmd:abstract
+                     |//*[@gco:isoType='srv:SV_ServiceIdentification']/gmd:abstract">
+
+      <sch:let name="missing" value="not(string(gco:CharacterString))
+                         or (@gco:nilReason)" />
+
+      <sch:let name="missingOtherLang" value="not(string(gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale=concat('#', $altLanguageId)]))" />
+
+      <sch:assert
+        test="not($missing) and not($missingOtherLang)"
+      >$loc/strings/MetadataAbstract</sch:assert>
+
+    </sch:rule>
+
+
+    <!-- Cited responsible party  - Organisation Name -->
+    <sch:rule context="//gmd:identificationInfo/*/gmd:citation/*/gmd:citedResponsibleParty/*/gmd:organisationName
+            |//*[@gco:isoType='gmd:MD_DataIdentification']/gmd:citation/*/gmd:citedResponsibleParty/*/gmd:organisationName
+            |//*[@gco:isoType='srv:SV_ServiceIdentification']/gmd:citation/*/gmd:citedResponsibleParty/*/gmd:organisationName">
+
+      <sch:let name="missing" value="not(string(gco:CharacterString))
+                or (@gco:nilReason)" />
+
+      <sch:let name="missingOtherLang" value="not(string(gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale=concat('#', $altLanguageId)]))" />
+
+
+      <sch:assert
+        test="not($missing) and not($missingOtherLang)"
+      >$loc/strings/CitedResponsiblePartyOrganisationName</sch:assert>
+
+      <sch:let name="government-titles" value="document(concat('file:///', replace(concat($thesaurusDir, '/external/thesauri/theme/GC_Departments.rdf'), '\\', '/')))"/>
+      <sch:let name="government-names" value="document(concat('file:///', replace(concat($thesaurusDir, '/external/thesauri/theme/GC_Org_Names.rdf'), '\\', '/')))"/>
+
+      <sch:let name="organisationName" value="gco:CharacterString" />
+      <sch:let name="isGovernmentOfCanada" value="starts-with(lower-case(normalize-space(tokenize($organisationName, ';')[1])), 'government of canada') or starts-with(lower-case(normalize-space(tokenize($organisationName, ';')[1])), 'gouvernement du canada')" />
+      <sch:let name="titleName" value="lower-case(normalize-space(tokenize($organisationName, ';')[2]))" />
+
+      <sch:let name="isGovernmentNameAllowed" value="(
+          string($government-names//rdf:Description[starts-with(normalize-space(lower-case($organisationName)), concat(normalize-space(lower-case(ns2:prefLabel[@xml:lang=$altLanguage2char])), ';'))]) or
+          string($government-names//rdf:Description[starts-with(normalize-space(lower-case($organisationName)), concat(normalize-space(lower-case(ns2:prefLabel[@xml:lang=$mainLanguage2char])), ';'))])
+        )"/>
+
+      <sch:assert test="($missing and $missingOtherLang) or ($isGovernmentNameAllowed and not($isGovernmentOfCanada)) or (not($isGovernmentNameAllowed) and not($isGovernmentOfCanada)) or ($isGovernmentOfCanada and (string($government-titles//rdf:Description[normalize-space(lower-case(ns2:prefLabel[@xml:lang=$mainLanguage2char])) = $titleName]) or
+                string($government-titles//rdf:Description[normalize-space(lower-case(ns2:prefLabel[@xml:lang=$altLanguage2char])) = $titleName]))
+              )">$loc/strings/*[name() = concat('CitedResponsibleContactGov', $mainLanguageText)]</sch:assert>
+
+      <sch:assert test="($missing and $missingOtherLang) or
+                $isGovernmentNameAllowed
+                ">$loc/strings/*[name() = concat('CitedResponsibleContactGovAllowed', $mainLanguageText)]</sch:assert>
+
+      <sch:let name="organisationNameOtherLang" value="gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale=concat('#', $altLanguageId)]" />
+      <sch:let name="isGovernmentOfCanadaOtherLang" value="starts-with(lower-case(normalize-space(tokenize($organisationNameOtherLang, ';')[1])), 'government of canada') or starts-with(lower-case(normalize-space(tokenize($organisationNameOtherLang, ';')[1])), 'gouvernement du canada')" />
+      <sch:let name="titleNameOtherLang" value="lower-case(normalize-space(tokenize($organisationNameOtherLang, ';')[2]))" />
+      <sch:let name="isGovernmentNameAllowedOtherLang" value="(
+          string($government-names//rdf:Description[starts-with(normalize-space(lower-case($organisationNameOtherLang)), concat(normalize-space(lower-case(ns2:prefLabel[@xml:lang=$altLanguage2char])), ';'))]) or
+          string($government-names//rdf:Description[starts-with(normalize-space(lower-case($organisationNameOtherLang)), concat(normalize-space(lower-case(ns2:prefLabel[@xml:lang=$mainLanguage2char])), ';'))])
+        )"/>
+
+      <sch:assert test="($missing and $missingOtherLang) or ($isGovernmentNameAllowedOtherLang and not($isGovernmentOfCanadaOtherLang)) or (not($isGovernmentNameAllowedOtherLang) and not($isGovernmentOfCanadaOtherLang)) or ($isGovernmentNameAllowedOtherLang and not($isGovernmentOfCanadaOtherLang)) or ($isGovernmentOfCanadaOtherLang and (string($government-titles//rdf:Description[normalize-space(lower-case(ns2:prefLabel[@xml:lang=$mainLanguage2char])) = $titleNameOtherLang]) or
+                string($government-titles//rdf:Description[normalize-space(lower-case(ns2:prefLabel[@xml:lang=$altLanguage2char])) = $titleNameOtherLang]))
+              )">$loc/strings/*[name() = concat('CitedResponsibleContactGov', $altLanguageText)]</sch:assert>
+      <sch:assert test="($missing and $missingOtherLang) or
+                $isGovernmentNameAllowedOtherLang
+                ">$loc/strings/*[name() = concat('CitedResponsibleContactGovAllowed', $altLanguageText)]</sch:assert>
+    </sch:rule>
+
+
+    <!-- Cited responsible party  - Country  -->
+    <sch:rule context="//gmd:identificationInfo/*/gmd:citation/*/gmd:citedResponsibleParty//gmd:country
+             |//*[@gco:isoType='gmd:MD_DataIdentification']/gmd:citation/*/gmd:citedResponsibleParty//gmd:country
+             |//*[@gco:isoType='srv:SV_ServiceIdentification']/gmd:citation/*/gmd:citedResponsibleParty//gmd:country">
+      <sch:let name="country-values" value="document(concat('file:///', replace(concat($thesaurusDir, '/external/thesauri/theme/ISO_Countries.rdf'), '\\', '/')))"/>
+
+      <sch:let name="countryName" value="lower-case(gco:CharacterString)" />
+      <sch:let name="countryNameOtherLang" value="lower-case(gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale=concat('#', $altLanguageId)])" />
+
+      <sch:assert test="(not($countryName) or
+                ($countryName and (string($country-values//rdf:Description[lower-case(normalize-space(ns2:prefLabel[@xml:lang=$mainLanguage2char])) = $countryName]) or
+                string($country-values//rdf:Description[lower-case(normalize-space(ns2:prefLabel[@xml:lang=$altLanguage2char])) = $countryName]))))
+
+                and
+
+                (not($countryNameOtherLang) or
+                            ($countryNameOtherLang and (string($country-values//rdf:Description[lower-case(normalize-space(ns2:prefLabel[@xml:lang=$mainLanguage2char])) = $countryNameOtherLang]) or
+                            string($country-values//rdf:Description[lower-case(normalize-space(ns2:prefLabel[@xml:lang=$altLanguage2char])) = $countryNameOtherLang]))
+                            ))">$loc/strings/ECCountry</sch:assert>
+    </sch:rule>
+
+
+    <!-- Cited Responsible Party - Position name -->
+    <sch:rule context="//gmd:identificationInfo/*/gmd:citation/*/gmd:citedResponsibleParty/*/gmd:positionName
+            |//*[@gco:isoType='gmd:MD_DataIdentification']/gmd:citation/*/gmd:citedResponsibleParty/*/gmd:positionName
+            |//*[@gco:isoType='srv:SV_ServiceIdentification']/gmd:citation/*/gmd:citedResponsibleParty/*/gmd:positionName">
+
+      <sch:let name="missing" value="not(string(gco:CharacterString))
+                or (@gco:nilReason)" />
+
+      <sch:let name="missingOtherLang" value="not(string(gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale=concat('#', $altLanguageId)]))" />
+
+      <sch:assert
+        test="($missing and $missingOtherLang) or (not($missing) and not($missingOtherLang))"
+      >$loc/strings/CitedResponsiblePartyPositionName</sch:assert>
+
+    </sch:rule>
+
+
+    <!-- Cited Responsible Party - Phone -->
+    <sch:rule context="//gmd:identificationInfo/*/gmd:citation/*/gmd:citedResponsibleParty/*/gmd:contactInfo/*/gmd:phone/gmd:CI_Telephone/gmd:voice
+              |//*[@gco:isoType='gmd:MD_DataIdentification']/gmd:citation/*/gmd:citedResponsibleParty/*/gmd:contactInfo/*/gmd:phone/gmd:CI_Telephone/gmd:voice
+              |//*[@gco:isoType='srv:SV_ServiceIdentification']/gmd:citation/*/gmd:citedResponsibleParty/*/gmd:contactInfo/*/gmd:phone/gmd:CI_Telephone/gmd:voice">
+
+      <sch:let name="missing" value="not(string(gco:CharacterString))
+                " />
+
+      <sch:let name="missingOtherLang" value="not(string(gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale=concat('#', $altLanguageId)]))" />
+
+      <sch:assert
+        test="($missing and $missingOtherLang) or (not($missing) and not($missingOtherLang))"
+      >$loc/strings/CitedResponsiblePartyPhone</sch:assert>
+    </sch:rule>
+
+    <!-- Cited Responsible Party - Delivery point -->
+    <sch:rule context="//gmd:identificationInfo/*/gmd:citation/*/gmd:citedResponsibleParty/*/gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:deliveryPoint
+            |//*[@gco:isoType='gmd:MD_DataIdentification']/gmd:citation/*/gmd:citedResponsibleParty/*/gmd:CI_Contact//gmd:address/gmd:CI_Address/gmd:deliveryPoint
+            |//*[@gco:isoType='srv:SV_ServiceIdentification']/gmd:citation/*/gmd:citedResponsibleParty/*/gmd:CI_Contact//gmd:address/gmd:CI_Address/gmd:deliveryPoint">
+
+      <sch:let name="missing" value="not(string(gco:CharacterString))
+                " />
+
+      <sch:let name="missingOtherLang" value="not(string(gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale=concat('#', $altLanguageId)]))" />
+
+      <sch:assert
+        test="($missing and $missingOtherLang) or (not($missing) and not($missingOtherLang))"
+      >$loc/strings/CitedResponsiblePartyDeliveryPoint</sch:assert>
+    </sch:rule>
+
+
+    <!-- Cited Responsible Party - Electronic Mail -->
+    <sch:rule context="//gmd:identificationInfo/*/gmd:citation/*/gmd:citedResponsibleParty/*/gmd:contactInfo/*/gmd:address/gmd:CI_Address/gmd:electronicMailAddress
+                      |//*[@gco:isoType='gmd:MD_DataIdentification']/gmd:citation/*/gmd:citedResponsibleParty/*/gmd:contactInfo/*/gmd:address/gmd:CI_Address/gmd:electronicMailAddress
+                      |//*[@gco:isoType='srv:SV_ServiceIdentification']/gmd:citation/*/gmd:citedResponsibleParty/*/gmd:contactInfo/*/gmd:address/gmd:CI_Address/gmd:electronicMailAddress">
+
+      <sch:let name="missing" value="not(string(gco:CharacterString))
+                or (@gco:nilReason)" />
+
+      <sch:let name="missingOtherLang" value="not(string(gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale=concat('#', $altLanguageId)]))" />
+
+      <sch:assert
+        test="not($missing) and not($missingOtherLang)"
+
+      >$loc/strings/CitedResponsiblePartyElectronicMail</sch:assert>
+
+    </sch:rule>
+
+
+    <!-- Cited Responsible Party - Hours of service -->
+    <sch:rule context="//gmd:identificationInfo/*/gmd:citation/*/gmd:citedResponsibleParty/*/gmd:contactInfo/gmd:CI_Contact/gmd:hoursOfService
+            |//*[@gco:isoType='gmd:MD_DataIdentification']/gmd:citation/*/gmd:citedResponsibleParty/*/gmd:CI_Contact/gmd:hoursOfService
+            |//*[@gco:isoType='srv:SV_ServiceIdentification']/gmd:citation/*/gmd:citedResponsibleParty/*/gmd:CI_Contact/gmd:hoursOfService">
+
+      <sch:let name="missing" value="not(string(gco:CharacterString))
+                " />
+      <sch:let name="missingOtherLang" value="not(string(gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale=concat('#', $altLanguageId)]))" />
+
+      <sch:assert
+        test="($missing and $missingOtherLang) or (not($missing) and not($missingOtherLang))"
+      >$loc/strings/CitedResponsiblePartyHoursOfService</sch:assert>
+    </sch:rule>
+
+
+    <!-- Keywords -->
+    <sch:rule context="//gmd:identificationInfo/*/gmd:descriptiveKeywords/gmd:MD_Keywords/gmd:keyword">
+      <sch:let name="missing" value="not(string(gco:CharacterString))
+            or (@gco:nilReason)" />
+
+      <sch:let name="missingOtherLang" value="not(string(gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale=concat('#', $altLanguageId)]))" />
+
+      <sch:assert
+        test="not($missing) and not($missingOtherLang)"
+      >$loc/strings/FreeTextKeyword</sch:assert>
+
+    </sch:rule>
+
+
+    <!-- Thesaurus contact -->
+    <sch:rule context="//gmd:descriptiveKeywords/gmd:MD_Keywords/gmd:thesaurusName/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:organisationName">
+
+      <sch:let name="missing" value="not(string(gco:CharacterString))
+                or (@gco:nilReason)" />
+
+      <sch:let name="missingOtherLang" value="not(string(gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale=concat('#', $altLanguageId)]))" />
+
+
+      <sch:assert
+        test="not($missing) and not($missingOtherLang)"
+      >$loc/strings/OrganisationNameThesaurus</sch:assert>
+
+    </sch:rule>
+
+    <sch:rule context="//gmd:descriptiveKeywords">
+
+      <sch:let name="thesaurusNamePresent" value="count(gmd:MD_Keywords/gmd:thesaurusName/gmd:CI_Citation) > 0" />
+
+
+      <sch:let name="missingTitle" value="not(string(gmd:MD_Keywords/gmd:thesaurusName/gmd:CI_Citation/gmd:title/gco:CharacterString))
+              or (@gco:nilReason)" />
+
+      <sch:let name="missingTitleOtherLang" value="not(string(gmd:MD_Keywords/gmd:thesaurusName/gmd:CI_Citation/gmd:title/gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale=concat('#', $altLanguageId)]))" />
+
+      <sch:assert
+        test="not($thesaurusNamePresent) or ($thesaurusNamePresent and not($missingTitle) and not($missingTitleOtherLang))"
+      >$loc/strings/ECThesaurusTitle</sch:assert>
+
+
+      <sch:let name="missingPublication" value="count(gmd:MD_Keywords/gmd:thesaurusName/gmd:CI_Citation/gmd:date[gmd:CI_Date/gmd:dateType/gmd:CI_DateTypeCode/@codeListValue = 'RI_367']) = 0" />
+
+      <sch:assert
+        test="not($thesaurusNamePresent) or ($thesaurusNamePresent and not($missingPublication))"
+      >$loc/strings/ECThesaurusPubDate</sch:assert>
+
+      <sch:let name="missingCreation" value="count(gmd:MD_Keywords/gmd:thesaurusName/gmd:CI_Citation/gmd:date[gmd:CI_Date/gmd:dateType/gmd:CI_DateTypeCode/@codeListValue = 'RI_366']) = 0" />
+
+      <sch:assert
+        test="not($thesaurusNamePresent) or ($thesaurusNamePresent and not($missingCreation))"
+      >$loc/strings/ECThesaurusCreDate</sch:assert>
+
+
+      <sch:let name="missingRole" value="not(string(gmd:MD_Keywords/gmd:thesaurusName/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:role/gmd:CI_RoleCode/@codeListValue))" />
+
+      <sch:assert
+        test="not($thesaurusNamePresent) or ($thesaurusNamePresent and not($missingRole))"
+      >$loc/strings/ECThesaurusRole</sch:assert>
+
+      <sch:let name="missingOrganisation" value="not(string(gmd:MD_Keywords/gmd:thesaurusName/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:organisationName/gco:CharacterString))
+              or (@gco:nilReason)" />
+
+      <sch:let name="missingOrganisationOtherLang" value="not(string(gmd:MD_Keywords/gmd:thesaurusName/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:organisationName/gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale=concat('#', $altLanguageId)]))" />
+
+      <sch:assert
+        test="not($thesaurusNamePresent) or ($thesaurusNamePresent and not($missingOrganisation) and not($missingOrganisationOtherLang))"
+      >$loc/strings/ECThesaurusOrg</sch:assert>
+
+      <sch:let name="emailPresent" value="count(gmd:MD_Keywords/gmd:thesaurusName/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:electronicMailAddress) > 0" />
+
+      <sch:let name="missingEmail" value="not(string(gmd:MD_Keywords/gmd:thesaurusName/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:electronicMailAddress/gco:CharacterString))
+              or (@gco:nilReason)" />
+
+      <sch:let name="missingEmailOtherLang" value="not(string(gmd:MD_Keywords/gmd:thesaurusName/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:electronicMailAddress/gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale=concat('#', $altLanguageId)]))" />
+
+      <sch:assert
+        test="not($thesaurusNamePresent) or ($thesaurusNamePresent and (not($emailPresent) or ($emailPresent and not($missingEmail) and not($missingEmailOtherLang))))"
+      >$loc/strings/ECThesaurusEmail</sch:assert>
+    </sch:rule>
+
+    <!-- Supplemental information -->
+    <sch:rule context="//gmd:identificationInfo/*/gmd:supplementalInformation
+          |//*[@gco:isoType='gmd:MD_DataIdentification']/gmd:supplementalInformation
+          |//*[@gco:isoType='srv:SV_ServiceIdentification']/gmd:supplementalInformation">
+
+      <sch:let name="missing" value="not(string(gco:CharacterString))
+              or (@gco:nilReason)" />
+
+      <sch:let name="missingOtherLang" value="not(string(gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale=concat('#', $altLanguageId)]))" />
+
+
+      <sch:assert
+        test="($missing and $missingOtherLang) or (not($missing) and not($missingOtherLang))"
+      >$loc/strings/SupplementalInfo</sch:assert>
+    </sch:rule>
+
+
+    <!-- Constraints -->
+
+    <!-- Note (Other constraints) -->
+    <sch:rule context="//gmd:identificationInfo/*/gmd:resourceConstraints/gmd:MD_LegalConstraints/gmd:otherConstraints">
+
+      <sch:let name="missing" value="not(string(gco:CharacterString))
+                " />
+
+      <sch:let name="missingOtherLang" value="not(string(gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale=concat('#', $altLanguageId)]))" />
+
+      <sch:assert
+        test="($missing and $missingOtherLang) or (not($missing) and not($missingOtherLang))"
+      >$loc/strings/OtherConstraintsNote2</sch:assert>
+
+      <sch:let name="filledFine" value="(
+                (string(gco:CharacterString) or string(gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale=concat('#', $altLanguageId)]))
+                and (../gmd:accessConstraints/gmd:MD_RestrictionCode/@codeListValue = 'RI_609'
+                or ../gmd:useConstraints/gmd:MD_RestrictionCode/@codeListValue = 'RI_609')) or
+
+                (not(string(gco:CharacterString)) and not(string(gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale=concat('#', $altLanguageId)]))
+                and (../gmd:accessConstraints/gmd:MD_RestrictionCode/@codeListValue != 'RI_609'
+                and ../gmd:useConstraints/gmd:MD_RestrictionCode/@codeListValue != 'RI_609')
+                )" />
+      <sch:assert
+        test="$filledFine"
+      >$loc/strings/OtherConstraintsNote</sch:assert>
+
+    </sch:rule>
+
+    <sch:rule context="//gmd:MD_SecurityConstraints/gmd:userNote">
+
+      <sch:let name="missingTitle" value="not(string(gco:CharacterString))
+              or (@gco:nilReason)" />
+
+      <sch:let name="missingTitleOtherLang" value="not(string(gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale=concat('#', $altLanguageId)]))" />
+
+      <sch:let name="security-level-list" value="document(concat('file:///', replace(concat($thesaurusDir, '/external/thesauri/theme/GC_Security_Level.rdf'), '\\', '/')))"/>
+
+      <sch:let name="userNote" value="gco:CharacterString" />
+      <sch:let name="userNoteTranslated" value="gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale=concat('#', $altLanguageId)]" />
+      <sch:let name="securityLevelList" value="geonet:securityLevelList($thesaurusDir)" />
+      <sch:let name="locMsg" value="concat($loc/strings/SecurityLevel, $securityLevelList)" />
+
+      <sch:assert test="($missingTitle and $missingTitleOtherLang) or
+                        (string($security-level-list//rdf:Description[@rdf:about = concat('http://geonetwork-opensource.org/EC/GC_Security_Classification#', $userNote)]) and
+                         string($security-level-list//rdf:Description[@rdf:about = concat('http://geonetwork-opensource.org/EC/GC_Security_Classification#',$userNoteTranslated)]))">$locMsg</sch:assert>
+
+    </sch:rule>
+
+    <!-- Use limitation -->
+    <sch:rule context="//gmd:identificationInfo/*/gmd:resourceConstraints/gmd:MD_LegalConstraints/gmd:useLimitation">
+
+      <sch:let name="missing" value="not(string(gco:CharacterString))
+                         or (@gco:nilReason)" />
+
+      <sch:let name="missingOtherLang" value="not(string(gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale=concat('#', $altLanguageId)]))" />
+
+      <sch:assert
+        test="not($missing) and not($missingOtherLang)"
+      >$loc/strings/UseLimitation</sch:assert>
+
+    </sch:rule>
+
+  </sch:pattern>
+
+  <!-- Distribution - Resources -->
+  <sch:pattern>
+    <sch:title>$loc/strings/Distribution</sch:title>
+
+    <!-- Distribution - Resources -->
+    <sch:rule context="//gmd:distributionInfo/gmd:MD_Distribution/gmd:transferOptions/gmd:MD_DigitalTransferOptions/gmd:onLine">
+
+      <sch:let name="missingLanguageForMapService" value="not(string(@xlink:role)) and (lower-case(gmd:CI_OnlineResource/gmd:protocol/gco:CharacterString) = 'ogc:wms' or lower-case(gmd:CI_OnlineResource/gmd:protocol/gco:CharacterString) = 'esri rest: map service')" />
+
+      <sch:assert
+        test="not($missingLanguageForMapService)"
+      >$loc/strings/MapServicesLanguage</sch:assert>
+
+
+      <!-- ResourceDescription -->
+      <sch:let name="smallcase" value="'abcdefghijklmnopqrstuvwxyz'" />
+      <sch:let name="uppercase" value="'ABCDEFGHIJKLMNOPQRSTUVWXYZ'" />
+      <sch:let name="formats-list" value="document(concat('file:///', replace(concat($thesaurusDir, '/external/thesauri/theme/GC_Resource_Formats.rdf'), '\\', '/')))"/>
+
+      <sch:let name="description" value="gmd:CI_OnlineResource/gmd:description/gco:CharacterString" />
+      <sch:let name="contentType" value="subsequence(tokenize($description, ';'), 1, 1)" />
+      <sch:let name="format" value="subsequence(tokenize($description, ';'), 2, 1)" />
+      <sch:let name="language" value="subsequence(tokenize($description, ';'), 3, 1)" />
+      <sch:let name="language_present" value="geonet:values-in($language,
+              ('eng', 'fra', 'spa', 'zxx'))"/>
+
+      <sch:let name="descriptionTranslated" value="gmd:CI_OnlineResource/gmd:description/gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale=concat('#', $altLanguageId)]" />
+      <sch:let name="contentTypeTranslated" value="subsequence(tokenize($descriptionTranslated, ';'), 1, 1)" />
+      <sch:let name="languageTranslated" value="subsequence(tokenize($descriptionTranslated, ';'), 3, 1)" />
+
+      <sch:let name="languageTranslated_present" value="geonet:values-in($languageTranslated,
+              ('eng', 'fra', 'spa', 'zxx'))"/>
+
+      <sch:assert test="($contentType = 'Web Service' or $contentType = 'Service Web' or
+              $contentType = 'Dataset' or $contentType = 'Données' or
+              $contentType = 'API' or $contentType = 'Application' or
+              $contentType='Supporting Document' or $contentType = 'Document de soutien') and
+              ($contentTypeTranslated = 'Web Service' or $contentTypeTranslated = 'Service Web' or
+              $contentTypeTranslated = 'Dataset' or $contentTypeTranslated = 'Données' or
+              $contentTypeTranslated = 'API' or $contentTypeTranslated = 'Application' or
+              $contentTypeTranslated='Supporting Document' or $contentTypeTranslated = 'Document de soutien')">$loc/strings/ResourceDescriptionContentType</sch:assert>
+
+
+      <sch:let name="formatTranslated" value="subsequence(tokenize($descriptionTranslated, ';'), 2, 1)" />
+      <sch:let name="resourceFormatsList" value="geonet:resourceFormatsList($thesaurusDir)" />
+      <sch:let name="locMsg" value="concat($loc/strings/ResourceDescriptionFormat, $resourceFormatsList)" />
+
+      <sch:assert test="string($formats-list//rdf:Description[@rdf:about = concat('http://geonetwork-opensource.org/EC/resourceformat#', $format)]) and
+                          string($formats-list//rdf:Description[@rdf:about = concat('http://geonetwork-opensource.org/EC/resourceformat#',$formatTranslated)])">$locMsg</sch:assert>
+
+      <sch:assert test="normalize-space($language) != '' and normalize-space($languageTranslated) != ''">$loc/strings/ResourceDescriptionLanguage</sch:assert>
+
+      <sch:assert test="$language_present and $languageTranslated_present">$loc/strings/ResourceDescriptionLanguage</sch:assert>
+
+    </sch:rule>
+
+
+    <!-- Distributor contact - Organisation Name -->
+    <sch:rule context="//gmd:distributionInfo/*/gmd:distributor/gmd:MD_Distributor/gmd:distributorContact/*/gmd:organisationName">
+
+      <sch:let name="missing" value="not(string(gco:CharacterString))
+                or (@gco:nilReason)" />
+
+      <sch:let name="missingOtherLang" value="not(string(gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale=concat('#', $altLanguageId)]))" />
+
+      <sch:assert
+        test="not($missing) and not($missingOtherLang)"
+      >$loc/strings/DistributorOrganisationName</sch:assert>
+
+
+      <sch:let name="government-titles" value="document(concat('file:///', replace(concat($thesaurusDir, '/external/thesauri/theme/GC_Departments.rdf'), '\\', '/')))"/>
+      <sch:let name="government-names" value="document(concat('file:///', replace(concat($thesaurusDir, '/external/thesauri/theme/GC_Org_Names.rdf'), '\\', '/')))"/>
+
+      <sch:let name="organisationName" value="gco:CharacterString" />
+      <sch:let name="isGovernmentOfCanada" value="starts-with(lower-case(normalize-space(tokenize($organisationName, ';')[1])), 'government of canada') or starts-with(lower-case(normalize-space(tokenize($organisationName, ';')[1])), 'gouvernement du canada')" />
+      <sch:let name="titleName" value="lower-case(normalize-space(tokenize($organisationName, ';')[2]))" />
+
+      <sch:let name="isGovernmentNameAllowed" value="(
+          string($government-names//rdf:Description[starts-with(normalize-space(lower-case($organisationName)), concat(normalize-space(lower-case(ns2:prefLabel[@xml:lang=$altLanguage2char])), ';'))]) or
+          string($government-names//rdf:Description[starts-with(normalize-space(lower-case($organisationName)), concat(normalize-space(lower-case(ns2:prefLabel[@xml:lang=$mainLanguage2char])), ';'))])
+        )"/>
+
+      <sch:assert test="($missing and $missingOtherLang) or ($isGovernmentNameAllowed and not($isGovernmentOfCanada)) or (not($isGovernmentNameAllowed) and not($isGovernmentOfCanada)) or ($isGovernmentOfCanada and (string($government-titles//rdf:Description[normalize-space(lower-case(ns2:prefLabel[@xml:lang=$mainLanguage2char])) = $titleName]) or
+                string($government-titles//rdf:Description[normalize-space(lower-case(ns2:prefLabel[@xml:lang=$altLanguage2char])) = $titleName]))
+              )">$loc/strings/*[name() = concat('DistributorGov', $mainLanguageText)]</sch:assert>
+
+      <sch:assert test="($missing and $missingOtherLang) or
+                $isGovernmentNameAllowed
+                ">$loc/strings/*[name() = concat('DistributorGovAllowed', $mainLanguageText)]</sch:assert>
+
+      <sch:let name="organisationNameOtherLang" value="gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale=concat('#', $altLanguageId)]" />
+      <sch:let name="isGovernmentOfCanadaOtherLang" value="starts-with(lower-case(normalize-space(tokenize($organisationNameOtherLang, ';')[1])), 'government of canada') or starts-with(lower-case(normalize-space(tokenize($organisationNameOtherLang, ';')[1])), 'gouvernement du canada')" />
+      <sch:let name="titleNameOtherLang" value="lower-case(normalize-space(tokenize($organisationNameOtherLang, ';')[2]))" />
+      <sch:let name="isGovernmentNameAllowedOtherLang" value="(
+          string($government-names//rdf:Description[starts-with(normalize-space(lower-case($organisationNameOtherLang)), concat(normalize-space(lower-case(ns2:prefLabel[@xml:lang=$altLanguage2char])), ';'))]) or
+          string($government-names//rdf:Description[starts-with(normalize-space(lower-case($organisationNameOtherLang)), concat(normalize-space(lower-case(ns2:prefLabel[@xml:lang=$mainLanguage2char])), ';'))])
+        )"/>
+
+      <sch:assert test="($missing and $missingOtherLang) or ($isGovernmentNameAllowedOtherLang and not($isGovernmentOfCanadaOtherLang)) or (not($isGovernmentNameAllowedOtherLang) and not($isGovernmentOfCanadaOtherLang)) or ($isGovernmentNameAllowedOtherLang and not($isGovernmentOfCanadaOtherLang)) or ($isGovernmentOfCanadaOtherLang and (string($government-titles//rdf:Description[normalize-space(lower-case(ns2:prefLabel[@xml:lang=$mainLanguage2char])) = $titleNameOtherLang]) or
+                string($government-titles//rdf:Description[normalize-space(lower-case(ns2:prefLabel[@xml:lang=$altLanguage2char])) = $titleNameOtherLang]))
+               )">$loc/strings/*[name() = concat('DistributorGov', $altLanguageText)]</sch:assert>
+      <sch:assert test="($missing and $missingOtherLang) or
+                $isGovernmentNameAllowedOtherLang
+                ">$loc/strings/*[name() = concat('DistributorGovAllowed', $altLanguageText)]</sch:assert>
+
+    </sch:rule>
+
+    <!-- Distributor - Position name -->
+    <sch:rule context="//gmd:distributionInfo/*/gmd:distributor/gmd:MD_Distributor/gmd:distributorContact/*/gmd:positionName">
+
+      <sch:let name="missing" value="not(string(gco:CharacterString))
+                or (@gco:nilReason)" />
+
+      <sch:let name="missingOtherLang" value="not(string(gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale=concat('#', $altLanguageId)]))" />
+
+      <sch:assert
+        test="($missing and $missingOtherLang) or (not($missing) and not($missingOtherLang))"
+      >$loc/strings/DistributorPositionName</sch:assert>
+
+    </sch:rule>
+
+    <!-- Distributor contact - Country -->
+    <sch:rule context="//gmd:distributionInfo/*/gmd:distributor/gmd:MD_Distributor/gmd:distributorContact//gmd:country">
+      <sch:let name="country-values" value="document(concat('file:///', replace(concat($thesaurusDir, '/external/thesauri/theme/ISO_Countries.rdf'), '\\', '/')))"/>
+
+      <sch:let name="countryName" value="lower-case(gco:CharacterString)" />
+      <sch:let name="countryNameOtherLang" value="lower-case(gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale=concat('#', $altLanguageId)])" />
+
+      <sch:assert test="(not($countryName) or
+              ($countryName and (string($country-values//rdf:Description[lower-case(normalize-space(ns2:prefLabel[@xml:lang=$mainLanguage2char])) = $countryName]) or
+              string($country-values//rdf:Description[lower-case(normalize-space(ns2:prefLabel[@xml:lang=$altLanguage2char])) = $countryName]))))
+
+              and
+
+              (not($countryNameOtherLang) or
+                          ($countryNameOtherLang and (string($country-values//rdf:Description[lower-case(normalize-space(ns2:prefLabel[@xml:lang=$mainLanguage2char])) = $countryNameOtherLang]) or
+                          string($country-values//rdf:Description[lower-case(normalize-space(ns2:prefLabel[@xml:lang=$altLanguage2char])) = $countryNameOtherLang]))
+                          ))">$loc/strings/ECCountry</sch:assert>
+
+    </sch:rule>
+
+    <!-- Distributor - Phone -->
+    <sch:rule context="//gmd:distributionInfo/*/gmd:distributor/gmd:MD_Distributor/gmd:distributorContact/*/gmd:contactInfo/*/gmd:phone/gmd:CI_Telephone/gmd:voice">
+
+      <sch:let name="missing" value="not(string(gco:CharacterString))
+                " />
+
+      <sch:let name="missingOtherLang" value="not(string(gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale=concat('#', $altLanguageId)]))" />
+
+      <sch:assert
+        test="($missing and $missingOtherLang) or (not($missing) and not($missingOtherLang))"
+      >$loc/strings/DistributorPhone</sch:assert>
+    </sch:rule>
+
+    <!-- Distributor - Delivery point -->
+    <sch:rule context="//gmd:distributionInfo/*/gmd:distributor/gmd:MD_Distributor/gmd:distributorContact/*/gmd:contactInfo/*/gmd:address/gmd:CI_Address/gmd:deliveryPoint">
+
+      <sch:let name="missing" value="not(string(gco:CharacterString))
+                    or (@gco:nilReason)" />
+
+      <sch:let name="missingOtherLang" value="not(string(gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale=concat('#', $altLanguageId)]))" />
+
+      <sch:assert
+        test="($missing and $missingOtherLang) or (not($missing) and not($missingOtherLang))"
+      >$loc/strings/DistributorDeliveryPoint</sch:assert>
+
+    </sch:rule>
+
+
+    <!-- Distributor - Electronic Mail -->
+    <sch:rule context="//gmd:distributionInfo/*/gmd:distributor/gmd:MD_Distributor/gmd:distributorContact/*/gmd:contactInfo/*/gmd:address/gmd:CI_Address/gmd:electronicMailAddress">
+
+      <sch:let name="missing" value="not(string(gco:CharacterString))
+                or (@gco:nilReason)" />
+
+      <sch:let name="missingOtherLang" value="not(string(gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale=concat('#', $altLanguageId)]))" />
+
+      <sch:assert
+        test="not($missing) and not($missingOtherLang)"
+
+      >$loc/strings/DistributorElectronicMail</sch:assert>
+
+    </sch:rule>
+
+
+    <!-- Distributor - Hours of service -->
+    <sch:rule context="//gmd:distributionInfo/*/gmd:distributor/gmd:MD_Distributor/gmd:distributorContact/*/gmd:contactInfo/gmd:CI_Contact/gmd:hoursOfService">
+
+      <sch:let name="missing" value="not(string(gco:CharacterString))
+                " />
+      <sch:let name="missingOtherLang" value="not(string(gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale=concat('#', $altLanguageId)]))" />
+
+      <sch:assert
+        test="($missing and $missingOtherLang) or (not($missing) and not($missingOtherLang))"
+      >$loc/strings/DistributorHoursOfService</sch:assert>
+    </sch:rule>
+
+  </sch:pattern>
+
+</sch:schema>

--- a/bridgemetadata/resources/iso19139.ca.hnap/schematron-rules-non-multilingual.sch
+++ b/bridgemetadata/resources/iso19139.ca.hnap/schematron-rules-non-multilingual.sch
@@ -1,0 +1,471 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sch:schema xmlns:sch="http://purl.oclc.org/dsdl/schematron"
+            xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+            xmlns:geonet="http://www.fao.org/geonetwork"
+            xmlns:xs="http://www.w3.org/2001/XMLSchema"
+            queryBinding="xslt2">
+
+  <sch:title xmlns="http://www.w3.org/2001/XMLSchema">HNAP validation rules (non-multilingual)</sch:title>
+  <sch:ns prefix="gml" uri="http://www.opengis.net/gml/3.2"/>
+  <sch:ns prefix="gml320" uri="http://www.opengis.net/gml"/>
+  <sch:ns prefix="gmd" uri="http://www.isotc211.org/2005/gmd"/>
+  <sch:ns prefix="srv" uri="http://www.isotc211.org/2005/srv"/>
+  <sch:ns prefix="gco" uri="http://www.isotc211.org/2005/gco"/>
+  <sch:ns prefix="gmx" uri="http://www.isotc211.org/2005/gmx"/>
+  <sch:ns prefix="geonet" uri="http://www.fao.org/geonetwork"/>
+  <sch:ns prefix="xsl" uri="http://www.w3.org/1999/XSL/Transform"/>
+  <sch:ns prefix="XslUtilHnap" uri="java:ca.gc.schema.iso19139hnap.util.XslUtilHnap"/>
+  <sch:ns prefix="tr" uri="java:org.fao.geonet.api.records.formatters.SchemaLocalizations"/>
+  <sch:ns prefix="xlink" uri="http://www.w3.org/1999/xlink"/>
+  <sch:ns prefix="rdf" uri="http://www.w3.org/1999/02/22-rdf-syntax-ns#"/>
+  <sch:ns prefix="ns2" uri="http://www.w3.org/2004/02/skos/core#"/>
+  <sch:ns prefix="rdfs" uri="http://www.w3.org/2000/01/rdf-schema#"/>
+
+  <sch:let name="schema" value="'iso19139.ca.HNAP'"/>
+<sch:let name="mainLanguage" value="if (normalize-space(//*[name(.)='gmd:MD_Metadata' or @gco:isoType='gmd:MD_Metadata']/gmd:language/gmd:LanguageCode/@codeListValue) != '')
+                                       then lower-case(normalize-space(//*[name(.)='gmd:MD_Metadata' or @gco:isoType='gmd:MD_Metadata']/gmd:language/gmd:LanguageCode/@codeListValue))
+                                       else if (contains(//*[name(.)='gmd:MD_Metadata' or @gco:isoType='gmd:MD_Metadata']/gmd:language/gco:CharacterString,';'))
+                                            then lower-case(normalize-space(substring-before(//*[name(.)='gmd:MD_Metadata' or @gco:isoType='gmd:MD_Metadata']/gmd:language/gco:CharacterString,';')))
+                                            else lower-case(//*[name(.)='gmd:MD_Metadata' or @gco:isoType='gmd:MD_Metadata']/gmd:language/gco:CharacterString)"/>
+  <sch:let name="mainLanguageId" value="//*[name(.)='gmd:MD_Metadata' or @gco:isoType='gmd:MD_Metadata']/gmd:locale/gmd:PT_Locale[gmd:languageCode/*/@codeListValue = $mainLanguage]/@id"/>
+  <sch:let name="mainLanguageText" value="if ($mainLanguage = 'fra') then 'French' else 'English'"/>
+  <sch:let name="mainLanguage2char" value="if ($mainLanguage = 'fra') then 'fr' else 'en'"/>
+
+  <xsl:function name="geonet:resourceFormatsList" as="xs:string">
+    <xsl:param name="thesaurusDir" as="xs:string"/>
+
+    <xsl:variable name="formats-list" select="document(concat('file:///', replace(concat($thesaurusDir, '/external/thesauri/theme/GC_Resource_Formats.rdf'), '\\', '/')))"/>
+
+    <xsl:variable name="v">
+      <xsl:for-each select="$formats-list//rdf:Description[ns2:prefLabel[@xml:lang='en']]">
+        <xsl:sort select="lower-case(@rdf:about)" order="ascending" />
+        <xsl:value-of select="replace(@rdf:about, 'http://geonetwork-opensource.org/EC/resourceformat#', '')" />
+        <xsl:if test="position() != last()">, </xsl:if>
+      </xsl:for-each>
+    </xsl:variable>
+
+    <xsl:value-of select="$v" />
+  </xsl:function>
+
+  <xsl:function name="geonet:securityLevelList" as="xs:string">
+    <xsl:param name="thesaurusDir" as="xs:string"/>
+
+    <xsl:variable name="security-level-list" select="document(concat('file:///', replace(concat($thesaurusDir, '/external/thesauri/theme/GC_Security_Level.rdf'), '\\', '/')))"/>
+
+    <xsl:variable name="v">
+      <xsl:for-each select="$security-level-list//rdf:Description[ns2:prefLabel[@xml:lang='en']]">
+        <xsl:sort select="lower-case(@rdf:about)" order="ascending" />
+        <xsl:value-of select="replace(@rdf:about, 'http://geonetwork-opensource.org/EC/GC_Security_Classification#', '')" />
+        <xsl:if test="position() != last()">, </xsl:if>
+      </xsl:for-each>
+    </xsl:variable>
+
+    <xsl:value-of select="$v" />
+  </xsl:function>
+
+  <!-- Checks if the values in arg (can be a comma separate list of items) are all in the searchStrings list -->
+  <xsl:function name="geonet:values-in" as="xs:boolean">
+    <xsl:param name="arg" as="xs:string?"/>
+    <xsl:param name="searchStrings" as="xs:string*"/>
+
+    <xsl:variable name="list" select="tokenize($arg, ',')" />
+    <xsl:sequence
+      select="
+            every $listValue in $list
+            satisfies exists($searchStrings[. = $listValue])
+            "
+    />
+  </xsl:function>
+
+  <!-- =============================================================
+  EC schematron rules for multilingual validation in metadata editor:
+  ============================================================= -->
+
+  <!--- Metadata pattern -->
+  <sch:pattern>
+    <sch:title>$loc/strings/Metadata</sch:title>
+
+    <!-- Metadata Standard Name -->
+    <sch:rule context="//gmd:metadataStandardName">
+
+      <sch:let name="correct" value="(($mainLanguage = 'eng' and gco:CharacterString = 'North American Profile of ISO 19115:2003 - Geographic information - Metadata') or
+                          ($mainLanguage = 'fra' and gco:CharacterString = 'Profil nord-américain de la norme ISO 19115:2003 - Information géographique - Métadonnées'))
+                            " />
+
+      <sch:assert
+        test="$correct"
+      >$loc/strings/MetadataStandardName</sch:assert>
+    </sch:rule>
+
+    <!-- Contact - Organisation Name -->
+    <sch:rule context="//gmd:contact/*/gmd:organisationName">
+
+      <sch:let name="mdLang" value="tokenize(/gmd:MD_Metadata/gmd:language/gco:CharacterString, ';')[1]" />
+
+      <sch:let name="missing" value="not(string(gco:CharacterString))
+                or (@gco:nilReason)" />
+
+      <sch:assert
+        test="not($missing)"
+      >$loc/strings/ContactOrganisationName</sch:assert>
+
+      <sch:let name="government-titles" value="document(concat('file:///', replace(concat($thesaurusDir, '/external/thesauri/theme/GC_Departments.rdf'), '\\', '/')))"/>
+      <sch:let name="government-names" value="document(concat('file:///', replace(concat($thesaurusDir, '/external/thesauri/theme/GC_Org_Names.rdf'), '\\', '/')))"/>
+
+      <sch:let name="organisationName" value="gco:CharacterString" />
+      <sch:let name="isGovernmentOfCanada" value="starts-with(lower-case(normalize-space(tokenize($organisationName, ';')[1])), 'government of canada') or starts-with(lower-case(normalize-space(tokenize($organisationName, ';')[1])), 'gouvernement du canada')" />
+      <sch:let name="titleName" value="lower-case(normalize-space(tokenize($organisationName, ';')[2]))" />
+
+      <sch:let name="isGovernmentNameAllowed" value="(
+          string($government-names//rdf:Description[starts-with(normalize-space(lower-case($organisationName)), concat(normalize-space(lower-case(ns2:prefLabel[@xml:lang=$mainLanguage2char])), ';'))])
+        )"/>
+
+
+      <sch:let name="isErrorContactGovMain" value="not(($missing) or ($isGovernmentNameAllowed and not($isGovernmentOfCanada)) or (not($isGovernmentNameAllowed) and not($isGovernmentOfCanada)) or ($isGovernmentOfCanada and (string($government-titles//rdf:Description[normalize-space(lower-case(ns2:prefLabel[@xml:lang=$mainLanguage2char])) = $titleName]))
+                     ))"/>
+
+      <sch:let name="isErrorContactGovMainAllowed" value="not($isErrorContactGovMain) and not(
+                ($missing) or
+                $isGovernmentNameAllowed
+                )"/>
+
+      <sch:assert test="not($isErrorContactGovMain)">$loc/strings/*[name() = concat('ContactGov', $mainLanguageText)]</sch:assert>
+
+      <sch:assert test="not($isErrorContactGovMainAllowed)">$loc/strings/*[name() = concat('ContactGovAllowed', $mainLanguageText)]</sch:assert>
+    </sch:rule>
+
+
+    <!-- Contact - Electronic Mail -->
+    <sch:rule context="//gmd:contact/*/gmd:contactInfo/*/gmd:address/gmd:CI_Address/gmd:electronicMailAddress">
+
+      <sch:let name="missing" value="not(string(gco:CharacterString))
+                or (@gco:nilReason)" />
+
+      <sch:assert
+        test="not($missing)"
+
+      >$loc/strings/ContactElectronicMail</sch:assert>
+
+    </sch:rule>
+  </sch:pattern>
+
+
+  <!--- Data Identification pattern -->
+  <sch:pattern>
+    <sch:title>$loc/strings/DataIdentification</sch:title>
+
+    <!-- Use Limitation -->
+    <sch:rule context="//gmd:identificationInfo/gmd:MD_DataIdentification
+            |//*[@gco:isoType='gmd:MD_DataIdentification']
+            |//*[@gco:isoType='srv:SV_ServiceIdentification']">
+
+      <sch:let name="open-licenses" value="document(concat('file:///', replace(concat($thesaurusDir, '/external/thesauri/theme/GC_Open_Licenses.rdf'), '\\', '/')))"/>
+
+      <sch:let name="openLicense" value="count(gmd:resourceConstraints/gmd:MD_LegalConstraints/gmd:useLimitation[
+               (normalize-space(gco:CharacterString) = $open-licenses//rdf:Description/ns2:prefLabel[@xml:lang=$mainLanguage2char])])" />
+
+
+      <sch:assert
+        test="$openLicense > 0"
+      >$loc/strings/OpenLicense</sch:assert>
+
+    </sch:rule>
+
+    <!-- Title -->
+    <sch:rule context="//gmd:identificationInfo/*/gmd:citation/*/gmd:title
+            |//*[@gco:isoType='gmd:MD_DataIdentification']/gmd:citation/*/gmd:title
+            |//*[@gco:isoType='srv:SV_ServiceIdentification']/gmd:citation/*/gmd:title">
+
+      <sch:let name="missing" value="not(string(gco:CharacterString))
+                or (@gco:nilReason)" />
+
+      <sch:assert
+        test="not($missing)"
+      >$loc/strings/MetadataTitle</sch:assert>
+    </sch:rule>
+
+    <!-- Abstract -->
+    <sch:rule context="//gmd:identificationInfo/*/gmd:abstract
+                     |//*[@gco:isoType='gmd:MD_DataIdentification']/gmd:abstract
+                     |//*[@gco:isoType='srv:SV_ServiceIdentification']/gmd:abstract">
+
+      <sch:let name="missing" value="not(string(gco:CharacterString))
+                         or (@gco:nilReason)" />
+
+      <sch:assert
+        test="not($missing)"
+      >$loc/strings/MetadataAbstract</sch:assert>
+
+    </sch:rule>
+
+    <!-- Cited responsible party  - Organisation Name -->
+    <sch:rule context="//gmd:identificationInfo/*/gmd:citation/*/gmd:citedResponsibleParty/*/gmd:organisationName
+            |//*[@gco:isoType='gmd:MD_DataIdentification']/gmd:citation/*/gmd:citedResponsibleParty/*/gmd:organisationName
+            |//*[@gco:isoType='srv:SV_ServiceIdentification']/gmd:citation/*/gmd:citedResponsibleParty/*/gmd:organisationName">
+
+      <sch:let name="missing" value="not(string(gco:CharacterString))
+                or (@gco:nilReason)" />
+
+
+      <sch:assert
+        test="not($missing)"
+      >$loc/strings/CitedResponsiblePartyOrganisationName</sch:assert>
+
+      <sch:let name="government-titles" value="document(concat('file:///', replace(concat($thesaurusDir, '/external/thesauri/theme/GC_Departments.rdf'), '\\', '/')))"/>
+      <sch:let name="government-names" value="document(concat('file:///', replace(concat($thesaurusDir, '/external/thesauri/theme/GC_Org_Names.rdf'), '\\', '/')))"/>
+
+      <sch:let name="organisationName" value="gco:CharacterString" />
+      <sch:let name="isGovernmentOfCanada" value="starts-with(lower-case(normalize-space(tokenize($organisationName, ';')[1])), 'government of canada') or starts-with(lower-case(normalize-space(tokenize($organisationName, ';')[1])), 'gouvernement du canada')" />
+      <sch:let name="titleName" value="lower-case(normalize-space(tokenize($organisationName, ';')[2]))" />
+
+      <sch:let name="isGovernmentNameAllowed" value="(
+          string($government-names//rdf:Description[starts-with(normalize-space(lower-case($organisationName)), concat(normalize-space(lower-case(ns2:prefLabel[@xml:lang=$mainLanguage2char])), ';'))])
+        )"/>
+
+      <sch:assert test="($missing) or ($isGovernmentNameAllowed and not($isGovernmentOfCanada)) or (not($isGovernmentNameAllowed) and not($isGovernmentOfCanada)) or ($isGovernmentOfCanada and (string($government-titles//rdf:Description[normalize-space(lower-case(ns2:prefLabel[@xml:lang=$mainLanguage2char])) = $titleName]))
+              )">$loc/strings/*[name() = concat('CitedResponsibleContactGov', $mainLanguageText)]</sch:assert>
+
+      <sch:assert test="($missing) or
+                $isGovernmentNameAllowed
+                ">$loc/strings/*[name() = concat('CitedResponsibleContactGovAllowed', $mainLanguageText)]</sch:assert>
+    </sch:rule>
+
+    <!-- Cited Responsible Party - Electronic Mail -->
+    <sch:rule context="//gmd:identificationInfo/*/gmd:citation/*/gmd:citedResponsibleParty/*/gmd:contactInfo/*/gmd:address/gmd:CI_Address/gmd:electronicMailAddress
+                      |//*[@gco:isoType='gmd:MD_DataIdentification']/gmd:citation/*/gmd:citedResponsibleParty/*/gmd:contactInfo/*/gmd:address/gmd:CI_Address/gmd:electronicMailAddress
+                      |//*[@gco:isoType='srv:SV_ServiceIdentification']/gmd:citation/*/gmd:citedResponsibleParty/*/gmd:contactInfo/*/gmd:address/gmd:CI_Address/gmd:electronicMailAddress">
+
+      <sch:let name="missing" value="not(string(gco:CharacterString))
+                or (@gco:nilReason)" />
+
+
+      <sch:assert
+        test="not($missing)"
+
+      >$loc/strings/CitedResponsiblePartyElectronicMail</sch:assert>
+
+    </sch:rule>
+
+    <!-- Keywords -->
+    <sch:rule context="//gmd:identificationInfo/*/gmd:descriptiveKeywords/gmd:MD_Keywords/gmd:keyword">
+      <sch:let name="missing" value="not(string(gco:CharacterString))
+            or (@gco:nilReason)" />
+
+      <sch:assert
+        test="not($missing)"
+      >$loc/strings/Keyword</sch:assert>
+
+    </sch:rule>
+
+    <!-- Thesaurus contact -->
+    <sch:rule context="//gmd:descriptiveKeywords/gmd:MD_Keywords/gmd:thesaurusName/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:organisationName">
+
+      <sch:let name="missing" value="not(string(gco:CharacterString))
+                or (@gco:nilReason)" />
+
+      <sch:assert
+        test="not($missing)"
+      >$loc/strings/OrganisationNameThesaurus</sch:assert>
+
+    </sch:rule>
+
+    <sch:rule context="//gmd:descriptiveKeywords">
+
+      <sch:let name="thesaurusNamePresent" value="count(gmd:MD_Keywords/gmd:thesaurusName/gmd:CI_Citation) > 0" />
+
+
+      <sch:let name="missingTitle" value="not(string(gmd:MD_Keywords/gmd:thesaurusName/gmd:CI_Citation/gmd:title/gco:CharacterString))
+              or (@gco:nilReason)" />
+
+
+      <sch:assert
+        test="not($thesaurusNamePresent) or ($thesaurusNamePresent and not($missingTitle))"
+      >$loc/strings/ECThesaurusTitle</sch:assert>
+
+
+      <sch:let name="missingPublication" value="count(gmd:MD_Keywords/gmd:thesaurusName/gmd:CI_Citation/gmd:date[gmd:CI_Date/gmd:dateType/gmd:CI_DateTypeCode/@codeListValue = 'RI_367']) = 0" />
+
+      <sch:assert
+        test="not($thesaurusNamePresent) or ($thesaurusNamePresent and not($missingPublication))"
+      >$loc/strings/ECThesaurusPubDate</sch:assert>
+
+      <sch:let name="missingCreation" value="count(gmd:MD_Keywords/gmd:thesaurusName/gmd:CI_Citation/gmd:date[gmd:CI_Date/gmd:dateType/gmd:CI_DateTypeCode/@codeListValue = 'RI_366']) = 0" />
+
+      <sch:assert
+        test="not($thesaurusNamePresent) or ($thesaurusNamePresent and not($missingCreation))"
+      >$loc/strings/ECThesaurusCreDate</sch:assert>
+
+
+      <sch:let name="missingRole" value="not(string(gmd:MD_Keywords/gmd:thesaurusName/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:role/gmd:CI_RoleCode/@codeListValue))" />
+
+      <sch:assert
+        test="not($thesaurusNamePresent) or ($thesaurusNamePresent and not($missingRole))"
+      >$loc/strings/ECThesaurusRole</sch:assert>
+
+      <sch:let name="missingOrganisation" value="not(string(gmd:MD_Keywords/gmd:thesaurusName/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:organisationName/gco:CharacterString))
+              or (@gco:nilReason)" />
+
+      <sch:assert
+        test="not($thesaurusNamePresent) or ($thesaurusNamePresent and not($missingOrganisation))"
+      >$loc/strings/ECThesaurusOrg</sch:assert>
+
+      <sch:let name="emailPresent" value="count(gmd:MD_Keywords/gmd:thesaurusName/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:electronicMailAddress) > 0" />
+
+      <sch:let name="missingEmail" value="not(string(gmd:MD_Keywords/gmd:thesaurusName/gmd:CI_Citation/gmd:citedResponsibleParty/gmd:CI_ResponsibleParty/gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:electronicMailAddress/gco:CharacterString))
+              or (@gco:nilReason)" />
+
+      <sch:assert
+        test="not($thesaurusNamePresent) or ($thesaurusNamePresent and (not($emailPresent) or ($emailPresent and not($missingEmail))))"
+      >$loc/strings/ECThesaurusEmail</sch:assert>
+    </sch:rule>
+
+    <!-- Note (Other constraints) -->
+    <sch:rule context="//gmd:identificationInfo/*/gmd:resourceConstraints/gmd:MD_LegalConstraints/gmd:otherConstraints">
+      <sch:let name="filledFine" value="(
+                (string(gco:CharacterString)
+                and (../gmd:accessConstraints/gmd:MD_RestrictionCode/@codeListValue = 'RI_609'
+                or ../gmd:useConstraints/gmd:MD_RestrictionCode/@codeListValue = 'RI_609')) or
+
+                (not(string(gco:CharacterString))
+                and (../gmd:accessConstraints/gmd:MD_RestrictionCode/@codeListValue != 'RI_609'
+                and ../gmd:useConstraints/gmd:MD_RestrictionCode/@codeListValue != 'RI_609')
+                ))" />
+      <sch:assert
+        test="$filledFine"
+      >$loc/strings/OtherConstraintsNote</sch:assert>
+    </sch:rule>
+
+    <sch:rule context="//gmd:MD_SecurityConstraints/gmd:userNote">
+
+      <sch:let name="missingTitle" value="not(string(gco:CharacterString))
+              or (@gco:nilReason)" />
+
+      <sch:let name="securityLevel" value="gco:CharacterString" />
+
+      <sch:let name="security-level-list" value="document(concat('file:///', replace(concat($thesaurusDir, '/external/thesauri/theme/GC_Security_Level.rdf'), '\\', '/')))"/>
+
+      <sch:let name="securityLevelList" value="geonet:securityLevelList($thesaurusDir)" />
+      <sch:let name="locMsg" value="concat($loc/strings/SecurityLevel, $securityLevelList)" />
+
+      <sch:assert test="$missingTitle or string($security-level-list//rdf:Description[@rdf:about = concat('http://geonetwork-opensource.org/EC/GC_Security_Classification#', $securityLevel)])">$locMsg</sch:assert>
+
+    </sch:rule>
+
+    <!-- Use limitation -->
+    <sch:rule context="//gmd:identificationInfo/*/gmd:resourceConstraints/gmd:MD_LegalConstraints/gmd:useLimitation">
+
+      <sch:let name="missing" value="not(string(gco:CharacterString))
+                         or (@gco:nilReason)" />
+
+      <sch:assert
+        test="not($missing)"
+      >$loc/strings/UseLimitation</sch:assert>
+
+    </sch:rule>
+
+  </sch:pattern>
+
+
+  <!-- Distribution - Resources -->
+  <sch:pattern>
+  <sch:title>$loc/strings/Distribution</sch:title>
+
+    <!-- Distribution - Resources -->
+    <sch:rule context="//gmd:distributionInfo/gmd:MD_Distribution/gmd:transferOptions/gmd:MD_DigitalTransferOptions/gmd:onLine">
+
+      <sch:let name="missingLanguageForMapService" value="not(string(@xlink:role)) and (lower-case(gmd:CI_OnlineResource/gmd:protocol/gco:CharacterString) = 'ogc:wms' or lower-case(gmd:CI_OnlineResource/gmd:protocol/gco:CharacterString) = 'esri rest: map service')" />
+
+      <sch:assert
+        test="not($missingLanguageForMapService)"
+      >$loc/strings/MapServicesLanguage</sch:assert>
+
+
+      <!-- ResourceDescription -->
+      <sch:let name="smallcase" value="'abcdefghijklmnopqrstuvwxyz'" />
+      <sch:let name="uppercase" value="'ABCDEFGHIJKLMNOPQRSTUVWXYZ'" />
+      <sch:let name="formats-list" value="document(concat('file:///', replace(concat($thesaurusDir, '/external/thesauri/theme/GC_Resource_Formats.rdf'), '\\', '/')))"/>
+
+      <sch:let name="description" value="gmd:CI_OnlineResource/gmd:description/gco:CharacterString" />
+      <sch:let name="contentType" value="subsequence(tokenize($description, ';'), 1, 1)" />
+      <sch:let name="format" value="subsequence(tokenize($description, ';'), 2, 1)" />
+      <sch:let name="language" value="subsequence(tokenize($description, ';'), 3, 1)" />
+      <sch:let name="language_present" value="geonet:values-in($language,
+              ('eng', 'fra', 'spa', 'zxx'))"/>
+
+
+      <sch:assert test="($contentType = 'Web Service' or $contentType = 'Service Web' or
+              $contentType = 'Dataset' or $contentType = 'Données' or
+              $contentType = 'API' or $contentType = 'Application' or
+              $contentType='Supporting Document' or $contentType = 'Document de soutien')">$loc/strings/ResourceDescriptionContentType</sch:assert>
+
+
+      <sch:let name="resourceFormatsList" value="geonet:resourceFormatsList($thesaurusDir)" />
+      <sch:let name="locMsg" value="concat($loc/strings/ResourceDescriptionFormat, $resourceFormatsList)" />
+
+      <sch:assert test="string($formats-list//rdf:Description[@rdf:about = concat('http://geonetwork-opensource.org/EC/resourceformat#', $format)])">$locMsg</sch:assert>
+
+      <sch:assert test="normalize-space($language) != ''">$loc/strings/ResourceDescriptionLanguage</sch:assert>
+
+      <sch:assert test="$language_present">$loc/strings/ResourceDescriptionLanguage</sch:assert>
+
+    </sch:rule>
+
+
+
+
+    <!-- Distributor contact - Organisation Name -->
+    <sch:rule context="//gmd:distributionInfo/*/gmd:distributor/gmd:MD_Distributor/gmd:distributorContact/*/gmd:organisationName">
+
+      <sch:let name="missing" value="not(string(gco:CharacterString))
+                or (@gco:nilReason)" />
+
+      <sch:assert
+        test="not($missing)"
+      >$loc/strings/DistributorOrganisationName</sch:assert>
+
+
+      <sch:let name="government-titles" value="document(concat('file:///', replace(concat($thesaurusDir, '/external/thesauri/theme/GC_Departments.rdf'), '\\', '/')))"/>
+      <sch:let name="government-names" value="document(concat('file:///', replace(concat($thesaurusDir, '/external/thesauri/theme/GC_Org_Names.rdf'), '\\', '/')))"/>
+
+      <sch:let name="organisationName" value="gco:CharacterString" />
+      <sch:let name="isGovernmentOfCanada" value="starts-with(lower-case(normalize-space(tokenize($organisationName, ';')[1])), 'government of canada') or starts-with(lower-case(normalize-space(tokenize($organisationName, ';')[1])), 'gouvernement du canada')" />
+      <sch:let name="titleName" value="lower-case(normalize-space(tokenize($organisationName, ';')[2]))" />
+
+      <sch:let name="isGovernmentNameAllowed" value="(
+          string($government-names//rdf:Description[starts-with(normalize-space(lower-case($organisationName)), concat(normalize-space(lower-case(ns2:prefLabel[@xml:lang=$mainLanguage2char])), ';'))])
+        )"/>
+
+      <sch:assert test="($missing) or ($isGovernmentNameAllowed and not($isGovernmentOfCanada)) or (not($isGovernmentNameAllowed) and not($isGovernmentOfCanada)) or ($isGovernmentOfCanada and (string($government-titles//rdf:Description[normalize-space(lower-case(ns2:prefLabel[@xml:lang=$mainLanguage2char])) = $titleName]))
+              )">$loc/strings/*[name() = concat('DistributorGov', $mainLanguageText)]</sch:assert>
+
+      <sch:assert test="($missing) or
+                $isGovernmentNameAllowed
+                ">$loc/strings/*[name() = concat('DistributorGovAllowed', $mainLanguageText)]</sch:assert>
+    </sch:rule>
+
+    <!-- Distributor contact - Country -->
+    <sch:rule context="//gmd:distributionInfo/*/gmd:distributor/gmd:MD_Distributor/gmd:distributorContact//gmd:country">
+      <sch:let name="country-values" value="document(concat('file:///', replace(concat($thesaurusDir, '/external/thesauri/theme/ISO_Countries.rdf'), '\\', '/')))"/>
+
+      <sch:let name="countryName" value="lower-case(gco:CharacterString)" />
+
+      <sch:assert test="(not($countryName) or
+              ($countryName and (string($country-values//rdf:Description[lower-case(normalize-space(ns2:prefLabel[@xml:lang=$mainLanguage2char])) = $countryName]))))">$loc/strings/ECCountry</sch:assert>
+
+    </sch:rule>
+
+    <!-- Distributor - Electronic Mail -->
+    <sch:rule context="//gmd:distributionInfo/*/gmd:distributor/gmd:MD_Distributor/gmd:distributorContact/*/gmd:contactInfo/*/gmd:address/gmd:CI_Address/gmd:electronicMailAddress">
+
+      <sch:let name="missing" value="not(string(gco:CharacterString))
+                  or (@gco:nilReason)" />
+
+      <sch:assert
+        test="not($missing)"
+
+      >$loc/strings/DistributorElectronicMail</sch:assert>
+
+    </sch:rule>
+
+  </sch:pattern>
+</sch:schema>

--- a/setup.py
+++ b/setup.py
@@ -12,5 +12,5 @@ setup(
     url="",
     packages=["bridgemetadata"],
     include_package_data=True,
-    entry_points={"console_scripts": ["md2md=bridgemetadata.convert:main"]},
+    entry_points={"console_scripts": ["md2md=bridgemetadata.convert:main","md-eval=bridgemetadata.convert:validate"]},
 )


### PR DESCRIPTION
This is a Proof of Concept to verify if it makes sense to use lxml for schematron validation.
It adds capability to evaluate a metadata document to a set of schematron rules extracted from metadata101.org

Metadata101.org uses schematron based on xslt.v2
lxml however supports only xslt.v1

It requires a backport of the schematron rules to v1, which is quite impactfull

run the validation as

```
md-eval example.xml
```
result is an array of titles of tests failing
![image](https://user-images.githubusercontent.com/299829/104584739-50a9fa00-5663-11eb-807f-bdc1c44c73a9.png)
